### PR TITLE
Format abstracts (in publication lists) in pure AsciiDoc

### DIFF
--- a/en/modules/ROOT/nav.adoc
+++ b/en/modules/ROOT/nav.adoc
@@ -85,7 +85,7 @@
 // ** xref:en:understanding:history.adoc[History of the project]
 // ** xref:en:understanding:research.adoc[Research]
 ** xref:en:understanding:social-contract.adoc[Social Contract]
-** xref:en:publications:index.adoc[Publications]
+** Publications
 *** xref:en:publications:catalan.adoc[Catalan]
 *** xref:en:publications:english.adoc[English]
 *** xref:en:publications:french.adoc[French]

--- a/en/modules/publications/pages/catalan.adoc
+++ b/en/modules/publications/pages/catalan.adoc
@@ -1,3 +1,4 @@
+[.publications]
 = Catalan Publications
 
 == Media

--- a/en/modules/publications/pages/catalan.adoc
+++ b/en/modules/publications/pages/catalan.adoc
@@ -1,7 +1,5 @@
 = Catalan Publications
 
-== Media 
+== Media
 
-* Barandiaran, X. E., Monterde, A., & Pin, G. (2016). Decidim.barcelona: autonomía, participación y software libre - Software libre. In Xarxaip (Ed.), _Programari lliure i de codi obert-Societat lliure i govern obert._ (pp. 31–32). http://softwarelibre.xarxaip.cat/18.html
-
-
+* Barandiaran, X. E., Monterde, A., & Pin, G. (2016). Decidim.barcelona: autonomía, participación y software libre - Software libre. In Xarxaip (Ed.), _Programari lliure i de codi obert-Societat lliure i govern obert._ (pp. 31–32). http://softwarelibre.xarxaip.cat/18.html.

--- a/en/modules/publications/pages/english.adoc
+++ b/en/modules/publications/pages/english.adoc
@@ -2,11 +2,21 @@
 
 == Media
 
-* Barandiaran, X. E., & iaran. (2018, April 24). _What is Decidim?_ https://xabier.barandiaran.net/2018/04/24/what-is-decidim/ +
-pass:[<div class="biblio-abstract">][.biblio-abstract-label]#Abstract.# Many people ask what is this project called “Decidim” to which I have devoted my last two year of work with complete dedication. I wanted to share a brief summary here. This text is the…pass:[</div>]
+* Barandiaran, X. E. (2018, April 24). _What is Decidim?_ https://xabier.barandiaran.net/2018/04/24/what-is-decidim/
++
+.Abstract
+[%collapsible]
+====
+Many people ask what is this project called “Decidim” to which I have devoted my last two year of work with complete dedication. I wanted to share a brief summary here. This text is the introduction of the Decidim’s White Paper (I am writing with Antonio Calleja and Arnau Monterde), to be published soon. I have systematized this text myself but it is really the product of a big group of people that have contributed to this project since its inception (Arnau Monerde, Andrés Lucena, Antonio Calleja, Carol Romero, Pablo Aragón and many others).
+====
 
-* Stark, K. (2017, May 9). _Barcelona’s Decidim Offers Open-Source Platform for Participatory Democracy Projects_. https://www.shareable.net/blog/barcelonas-decidim-offers-open-source-platform-for-participatory-democracy-projects +
-pass:[<div class="biblio-abstract">][.biblio-abstract-label]#Abstract.# The word Decidim translated from Catalan means we decide, and it’s the name of Barcelona’s digital infrastructure for participatory democracy. One part functional database and one part political statement, organizers say Decidim is key to a broad digital transformation that is taking place in Barcelona — its institutions, markets, and economy.pass:[</div>]
+* Stark, K. (2017, May 9). _Barcelona’s Decidim Offers Open-Source Platform for Participatory Democracy Projects_. https://www.shareable.net/blog/barcelonas-decidim-offers-open-source-platform-for-participatory-democracy-projects
++
+.Abstract
+[%collapsible]
+====
+The word Decidim translated from Catalan means we decide, and it’s the name of Barcelona’s digital infrastructure for participatory democracy. One part functional database and one part political statement, organizers say Decidim is key to a broad digital transformation that is taking place in Barcelona — its institutions, markets, and economy.
+====
 
 * _Decidim: Free Open-Source participatory democracy for cities and organizations | Hacker News_. (n.d.). Retrieved January 21, 2019, from https://news.ycombinator.com/item?id=18952328
 

--- a/en/modules/publications/pages/english.adoc
+++ b/en/modules/publications/pages/english.adoc
@@ -1,3 +1,4 @@
+[.publications]
 = English Publications
 
 == Media

--- a/en/modules/publications/pages/french.adoc
+++ b/en/modules/publications/pages/french.adoc
@@ -1,4 +1,4 @@
-
+[.publications]
 = French Publications
 
 == Media

--- a/en/modules/publications/pages/french.adoc
+++ b/en/modules/publications/pages/french.adoc
@@ -3,8 +3,22 @@
 
 == Media
 
-* Politics, O. S. (2018a, March 7). _Decidim, la plateforme de participation citoyenne d’envergure européenne_. https://medium.com/open-source-politics/decidim-la-plateforme-de-participation-citoyenne-denvergure-europ%C3%A9enne-9b3cb92681e5 +
-pass:[<div class="biblio-abstract">][.biblio-abstract-label]#Abstract.# Cet article est basé sur une série de conversations que nous avons eues avec Pablo Aragon, Xabier Barandiaran, Josep Jaume[1] et de…pass:[</div>]
+* Politics, O. S. (2018a, March 7). _Decidim, la plateforme de participation citoyenne d’envergure européenne_. https://opensourcepolitics.eu/actualites/decidim-la-plateforme-de-participation-citoyenne-denvergure-europeenne/
++
+.Abstract
+[%collapsible]
+====
+Cet article sur Decidim (plateforme de participation citoyenne) est basé sur une série de conversations que nous avons eues avec Pablo Aragon, Xabier Barandiaran, Josep Jaume et de nombreux autres collaborateurs du projet open source Decidim.
+====
 
-* Politics, O. S. (2018b, March 7). _Le Contrat Social de Decidim, un texte fondateur_. https://medium.com/open-source-politics/le-contrat-social-de-decidim-un-texte-fondateur-7a8916213270 +
-pass:[<div class="biblio-abstract">][.biblio-abstract-label]#Abstract.# Nous reproduisons ici, pour la première fois en français, le « Contrat Social » de la plateforme Decidim, traduit du catalan en passant…pass:[</div>]
+* Politics, O. S. (2018b, March 7). _Le Contrat Social de Decidim, un texte fondateur_. https://opensourcepolitics.eu/actualites/le-contrat-social-de-decidim-un-texte-fondateur/
++
+.Abstract
+[%collapsible]
+====
+Nous reproduisons ici, pour la première fois en français, le « Contrat Social » de la plateforme Decidim, traduit du catalan en passant par l’anglais. Toute traduction implique nécessairement des choix, qui peuvent par endroit altérer l’intention initiale de la phrase, mais nous avons tenté de restituer au mieux l’esprit de l’original.
+
+Le choix d’intituler ce document « Contrat social » est lourd de sens puisque ce concept est l’un des plus connus de la philosophie politique. Initialement théorisé par Grotius au 17ème siècle avant d’être popularisé par Hobbes, Locke et Rousseau, le contrat social constitue une hypothèse de réponse à plusieurs questions philosophiques fondamentales. L’objectif est en effet de fournir un cadre conceptuel permettant d’expliquer la fondation de la société et de comprendre pourquoi l’être humain se soumet à des règles auxquelles il n’a pas choisi explicitement de se soumettre.
+
+L’idée derrière la reprise de cette notion par les fondateurs de Decidim est donc d’assumer le développement d’un nouveau fonctionnement politique à travers l’adoption de cette plateforme. C’est donc la marque d’un renouvellement de la compréhension de notre participation, en tant qu’individus politiques, à la société. Cette conception renouvelée du poids politique du citoyen est issue directement, dans le cas de Decidim, de la relation étroite des leaders du projet avec le mouvement des Indignés, qui souhaitait explicitement refonder l’organisation du pouvoir politique pour obtenir une démocratie plus ouverte.
+====

--- a/en/modules/publications/pages/german.adoc
+++ b/en/modules/publications/pages/german.adoc
@@ -1,3 +1,4 @@
+[.publications]
 = German Publications
 
 == Media

--- a/en/modules/publications/pages/german.adoc
+++ b/en/modules/publications/pages/german.adoc
@@ -2,9 +2,18 @@
 
 == Media
 
-* _Wie Barcelona eine offene “Smart City” im Dienste des Gemeinwohls plant_. (2018, September 9). https://netzpolitik.org/2018/freie-software-als-oeffentliches-gut-und-was-rathaeuser-dafuer-tun-koennen/ +
-pass:[<div class="biblio-abstract">][.biblio-abstract-label]#Abstract.# Im Interview spricht Francesca Bria, Barcelonas Chief Technology and Digital Innovation Officer, über “Digitale Soziale Innovation” und passende Strategien um die lokale Wirtschaft, Privatsphäre und die demokratische Teilhabe der Bürger*innen auch in einer “Smart City” langfristig zu sichern und zupass:[</div>]
+* _Wie Barcelona eine offene “Smart City” im Dienste des Gemeinwohls plant_. (2018, September 9). https://netzpolitik.org/2018/freie-software-als-oeffentliches-gut-und-was-rathaeuser-dafuer-tun-koennen/
++
+.Abstract
+[%collapsible]
+====
+Im Interview spricht Francesca Bria, Barcelonas Chief Technology and Digital Innovation Officer, über “Digitale Soziale Innovation” und passende Strategien um die lokale Wirtschaft, Privatsphäre und die demokratische Teilhabe der Bürger*innen auch in einer “Smart City” langfristig zu sichern und zu.
+====
 
-* Macher, J. (n.d.). _Digital und demokratisch (neues deutschland)_. Retrieved December 7, 2019, from https://www.neues-deutschland.de/artikel/1129769.smart-city-digital-und-demokratisch.html +
-pass:[<div class="biblio-abstract">][.biblio-abstract-label]#Abstract.# In Barcelona bedeutet »Smart City«: Mehr Mitsprache für die Menschen. Andere Städte sind dem Beispiel gefolgt.pass:[</div>]
-
+* Macher, J. (n.d.). _Digital und demokratisch (neues deutschland)_. Retrieved December 7, 2019, from https://www.neues-deutschland.de/artikel/1129769.smart-city-digital-und-demokratisch.html
++
+.Abstract
+[%collapsible]
+====
+In Barcelona bedeutet »Smart City«: Mehr Mitsprache für die Menschen. Andere Städte sind dem Beispiel gefolgt.
+====

--- a/en/modules/publications/pages/italian.adoc
+++ b/en/modules/publications/pages/italian.adoc
@@ -1,3 +1,4 @@
+[.publications]
 = Italian Publications
 
 == Media

--- a/en/modules/publications/pages/italian.adoc
+++ b/en/modules/publications/pages/italian.adoc
@@ -2,7 +2,10 @@
 
 == Media
 
-* _Perché Barcelona Smart City è un modello per il mondo. Intervista a Francesca Bria_. (2018, August 13). http://www.designatlarge.it/barcelona-smart-city-francesca-bria/ +
-pass:[<div class="biblio-abstract">][.biblio-abstract-label]#Abstract.# La sovranità tecnologica ai cittadini. Ecco come Barcelona Smart City è diventata un modello per il mondo. Intervista alla CTO Francesca Briapass:[</div>]
-
-
+* _Perché Barcelona Smart City è un modello per il mondo. Intervista a Francesca Bria_. (2018, August 13). http://www.designatlarge.it/barcelona-smart-city-francesca-bria/
++
+.Abstract
+[%collapsible]
+====
+La sovranità tecnologica ai cittadini. Ecco come Barcelona Smart City è diventata un modello per il mondo. Intervista alla CTO Francesca Bria.
+====

--- a/en/modules/publications/pages/spanish.adoc
+++ b/en/modules/publications/pages/spanish.adoc
@@ -10,34 +10,61 @@
 
 * Barandiaran, X. E., Monterde, A., & Pin, G. (2016b). Decidim.barcelona: autonomía, participación y software libre - Software libre. In Xarxaip (Ed.), _Programari lliure i de codi obert-Societat lliure i govern obert._ (pp. 31–32). http://softwarelibre.xarxaip.cat/18.html
 
-* Aragón, P., Kaltenbrunner, A., Calleja-López, A., Pereira, A., Monterde, A., Barandiaran, X. E., & Gómez, V. (2017). Deliberative Platform Design: The Case Study of the Online Discussions in Decidim Barcelona. _Social Informatics_, 277–287. https://doi.org/10.1007/978-3-319-67256-4_22 +
-pass:[<div class="biblio-abstract">][.biblio-abstract-label]#Abstract.# With the irruption of ICTs and the crisis of political representation, many online platforms have been developed with the aim of improving participatory democratic processes. However, regarding platforms for online petitioning, previous research has not found examples of how to effectively introduce discussions, a crucial feature to promote deliberation. In this study we focus on the case of Decidim Barcelona, the online participatory-democracy platform launched by the City Council of Barcelona in which proposals can be discussed with an interface that combines threaded discussions and comment alignment with the proposal. This innovative approach allows to examine whether neutral, positive or negative comments are more likely to generate discussion cascades. The results reveal that, with this interface, comments marked as negatively aligned with the proposal were more likely to engage users in online discussions and, therefore, helped to promote deliberative decision making.pass:[</div>]
+* Aragón, P., Kaltenbrunner, A., Calleja-López, A., Pereira, A., Monterde, A., Barandiaran, X. E., & Gómez, V. (2017). Deliberative Platform Design: The Case Study of the Online Discussions in Decidim Barcelona. _Social Informatics_, 277–287. https://doi.org/10.1007/978-3-319-67256-4_22
++
+.Abstract
+[%collapsible]
+====
+With the irruption of ICTs and the crisis of political representation, many online platforms have been developed with the aim of improving participatory democratic processes. However, regarding platforms for online petitioning, previous research has not found examples of how to effectively introduce discussions, a crucial feature to promote deliberation. In this study we focus on the case of Decidim Barcelona, the online participatory-democracy platform launched by the City Council of Barcelona in which proposals can be discussed with an interface that combines threaded discussions and comment alignment with the proposal. This innovative approach allows to examine whether neutral, positive or negative comments are more likely to generate discussion cascades. The results reveal that, with this interface, comments marked as negatively aligned with the proposal were more likely to engage users in online discussions and, therefore, helped to promote deliberative decision making.
+====
 
 * Borge, R., Balcells, J., Padró-Solanet, A., Batlle, A., Orte, A., & Serra, R. (n.d.). _La participación política a través de la plataforma Decidim: análisis de 11 municipios catalanes_.
 
 == Media 
 
-* Calleja-López, A., Monterde, A., & Barandiaran, X. E. (2017, October 18). _De las redes sociales a las redes (tecno)políticas: redes de tercera generación para la democracia del siglo XXI_ [Text]. http://tecnopolitica.net/content/de-las-redes-sociales-las-redes-tecnopol%C3%ADticas-redes-de-tercera-generaci%C3%B3n-para-la +
-pass:[<div class="biblio-abstract">][.biblio-abstract-label]#Abstract.# La sociedad deviene (en) red.pass:[</div>]
+* Calleja-López, A., Monterde, A., & Barandiaran, X. E. (2017, October 18). _De las redes sociales a las redes (tecno)políticas: redes de tercera generación para la democracia del siglo XXI_ [Text]. http://tecnopolitica.net/content/de-las-redes-sociales-las-redes-tecnopol%C3%ADticas-redes-de-tercera-generaci%C3%B3n-para-la
 
-* _TIPS - Cultura digital - La democracia 2.0_. (2017, February 2). http://www.rtve.es/alacarta/videos/tips/tips-cultura-digital-democracia-20/3896837/ +
-pass:[<div class="biblio-abstract">][.biblio-abstract-label]#Abstract.# TIPS - Cultura digital - La democracia 2.0, Tips online, completo y gratis en RTVE.es A la Carta. Todos los programas de Tips online en RTVE.es A la Cartapass:[</div>]
+* _TIPS - Cultura digital - La democracia 2.0_. (2017, February 2). http://www.rtve.es/alacarta/videos/tips/tips-cultura-digital-democracia-20/3896837/
++
+.Abstract
+[%collapsible]
+====
+Bruno Sokolowicz presenta varias plataformas digitales de democracia participativa y entrevista a Xabier Barandiaran, experto en innovación democrática.
+====
 
-[[ref-4881969-FWFFK8LS]]
-* Bravo, E. (2016, July 20). _Cómo mejorar Barcelona con la participación de sus ciudadanos_ [Magazzine]. http://www.yorokobu.es/barcelona-participacion/ +
-pass:[<div class="biblio-abstract">][.biblio-abstract-label]#Abstract.# El cricket es un deporte muy curioso. Los partidos pueden durar días y, entre sus reglas, está la de parar el juego para tomar el té. Una de las potencias en este deporte es Paquistán, país del que procede parte de la población inmigrante de Barcelona. Muchos de los miembros de esa comunidad llevan años […]pass:[</div>]
+* Bravo, E. (2016, July 20). _Cómo mejorar Barcelona con la participación de sus ciudadanos_ [Magazzine]. http://www.yorokobu.es/barcelona-participacion/
 
-* Barandiaran, X. E., Pereira, A., Monterde, A., & Calleja-López, A. (2016). _Plan de desarrollo Decidim Barcelona_. Ajuntament de Barcelona City Council. https://decidim-barcelona.s3.amazonaws.com/uploads/decidim/attachment/file/54/Plan_desarrollo_decidim.pdf +
-pass:[<div class="biblio-abstract">][.biblio-abstract-label]#Abstract.# Este documento detalla el futuro desarrollo de la plataforma digital de participación de l´Ajuntament de Barcelona, decidim.barcelona (disponible en URL https://decidim.barcelona). Los principales objetivos de la plataforma son articular, estandarizar, visualizar y comunicar todos los procesos de participación del Ajuntament de Barcelona y de la ciudad ofreciendo un servicio de infraestructura digital para la democracia directa y participativa a todas las escalas territoriales y asociativas de Barcelona. El documento detalla los objetivos de la plataforma, el flujo de desarrollo, las funcionalidades previstas, y un código ético-político.pass:[</div>]
+* Barandiaran, X. E., Pereira, A., Monterde, A., & Calleja-López, A. (2016). _Plan de desarrollo Decidim Barcelona_. Ajuntament de Barcelona City Council. https://decidim-barcelona.s3.amazonaws.com/uploads/decidim/attachment/file/54/Plan_desarrollo_decidim.pdf
++
+.Abstract
+[%collapsible]
+====
+Este documento detalla el futuro desarrollo de la plataforma digital de participación de l´Ajuntament de Barcelona, decidim.barcelona (disponible en URL https://decidim.barcelona). Los principales objetivos de la plataforma son articular, estandarizar, visualizar y comunicar todos los procesos de participación del Ajuntament de Barcelona y de la ciudad ofreciendo un servicio de infraestructura digital para la democracia directa y participativa a todas las escalas territoriales y asociativas de Barcelona. El documento detalla los objetivos de la plataforma, el flujo de desarrollo, las funcionalidades previstas, y un código ético-político.
+====
 
-* Participa Pamplona. (2017a, July 18). _Decidim Barcelona (Xabier Barandiaran)_. https://www.youtube.com/watch?v=zQYvdwGsg8M +
-pass:[<div class="biblio-abstract">][.biblio-abstract-label]#Abstract.# 1a Jornada de tecnología y democracia (24/05/2017). Infraestructuras digitales para la democracia. Decidim Barcelona Xabier Barandiaran. Coordinador del proyecto Decidim, asesor de la Regiduría de Participación del Ayuntamiento de Barcelona. Teknologia eta demokraziari buruzko 1. jardunaldia (24/05/2017). Demokrazia partizipatiborako azpiegitura digitalak Decidim Barcelona Xabier Barandiaran. Decidim proiektuaren koordinatzailea eta Bartzelonako Udaleko Partaidetza zinegotziaren aholkulariapass:[</div>]
+* Participa Pamplona. (2017a, July 18). _Decidim Barcelona (Xabier Barandiaran)_. https://www.youtube.com/watch?v=zQYvdwGsg8M
++
+.Abstract
+[%collapsible]
+====
+1a Jornada de tecnología y democracia (24/05/2017). Infraestructuras digitales para la democracia. Decidim Barcelona Xabier Barandiaran. Coordinador del proyecto Decidim, asesor de la Regiduría de Participación del Ayuntamiento de Barcelona.
+====
 
-* Participa Pamplona. (2017b, July 18). _Hacia una democracia participativa inteligente y democrática (Asier Gallastegui y Asier Amezaga)_. https://www.youtube.com/watch?v=z4FTUt8wnRs +
-pass:[<div class="biblio-abstract">][.biblio-abstract-label]#Abstract.# 1a Jornada de tecnología y democracia (24/05/2017). Infraestructuras digitales para la democracia. Decidim Barcelona Xabier Barandiaran. Coordinador del proyecto Decidim, asesor de la Regiduría de Participación del Ayuntamiento de Barcelona. Teknologia eta demokraziari buruzko 1. jardunaldia (24/05/2017). Demokrazia partizipatiborako azpiegitura digitalak Decidim Barcelona Xabier Barandiaran. Decidim proiektuaren koordinatzailea eta Bartzelonako Udaleko Partaidetza zinegotziaren aholkulariapass:[</div>]
+* Participa Pamplona. (2017b, July 18). _Hacia una democracia participativa inteligente y democrática (Asier Gallastegui y Asier Amezaga)_. https://www.youtube.com/watch?v=z4FTUt8wnRs
++
+.Abstract
+[%collapsible]
+====
+1a Jornada de tecnología y democracia (24/05/2017). Infraestructuras digitales para la democracia. Decidim Barcelona Xabier Barandiaran. Coordinador del proyecto Decidim, asesor de la Regiduría de Participación del Ayuntamiento de Barcelona.
+====
 
-* Participa Pamplona. (2017c, July 18). _Metadecidim. Diseño participativo de la plataforma Decidim Barcelona (Andrés Pereira de Lucena)_. https://www.youtube.com/watch?v=I31yY4ip3rk +
-pass:[<div class="biblio-abstract">][.biblio-abstract-label]#Abstract.# 1a Jornada de tecnología y democracia (24/05/2017). Infraestructuras digitales para la democracia. Andrés Pereira de Lucena. Presidente de la asociación aLabs, coordinador técnico y arquitecto técnico de Decidim. Teknologia eta demokraziari buruzko 1. jardunaldia (24/05/2017). Demokrazia partizipatiborako azpiegitura digitalak Andrés Pereira de Lucena. aLabs elkarteko lehendakaria eta Dicidimen koordinatzaile teknikoa eta arkitekto teknikoa.pass:[</div>]
+* Participa Pamplona. (2017c, July 18). _Metadecidim. Diseño participativo de la plataforma Decidim Barcelona (Andrés Pereira de Lucena)_. https://www.youtube.com/watch?v=I31yY4ip3rk
++
+.Abstract
+[%collapsible]
+====
+1a Jornada de tecnología y democracia (24/05/2017). Infraestructuras digitales para la democracia. Andrés Pereira de Lucena. Presidente de la asociación aLabs, coordinador técnico y arquitecto técnico de Decidim.
+====
 
 * Barandiaran, X. E., & Romero, C. (2018, May 17). _Presentació Decidim Ada Lovelace_. https://www.youtube.com/watch?v=-3eh_v339Cg
 

--- a/en/modules/publications/pages/spanish.adoc
+++ b/en/modules/publications/pages/spanish.adoc
@@ -1,3 +1,4 @@
+[.publications]
 = Spanish Publications
 
 == Academic

--- a/supplemental_ui/css/publications.css
+++ b/supplemental_ui/css/publications.css
@@ -1,0 +1,23 @@
+.publications .doc .exampleblock {
+  margin: 0rem 0 0;
+}
+
+.publications .doc .exampleblock .title {
+  display: none;
+}
+
+.publications .doc .exampleblock > .content {
+  background: var(--body-background);
+  border: none;
+  font-size: 0.85rem;
+  margin-left: 0.8rem;
+}
+
+.publications .doc .exampleblock > .content > :first-child {
+  margin-top: 0rem;
+}
+
+.publications .doc .exampleblock > .content > :first-child p::before {
+  content: "Abstract. ";
+  font-style: italic;
+}

--- a/supplemental_ui/partials/head-meta.hbs
+++ b/supplemental_ui/partials/head-meta.hbs
@@ -1,1 +1,2 @@
 <link rel="stylesheet" href="{{uiRootPath}}/css/search.css">
+<link rel="stylesheet" href="{{uiRootPath}}/css/publications.css">


### PR DESCRIPTION
Abstracts cannot be hidden, yet. They will (automatically) be once https://gitlab.com/antora/antora/-/issues/522 is implemented in Antora. When this happens, modifications to `supplemental_files` introduced here could be removed.

A workaround that could be implemented meanwhile is using JS or heavy CSS tricks to show/hide the abstract, but I don't think it's worthwhile. 