### PR TITLE
Fix typo

### DIFF
--- a/en/modules/develop/pages/notifications.adoc
+++ b/en/modules/develop/pages/notifications.adoc
@@ -2,7 +2,7 @@
 
 In Decidim, notifications may mean two things:
 
-* he concept of notifying an event to a user. This is the wider use of "notification".
+* the concept of notifying an event to a user. This is the wider use of "notification".
 * the notification's participant space, which lists the ``Decidim::Notification``s she has received.
 
 So, in the wider sense, notifications are messages that are sent to the users, admins or participants, when something interesting occurs in the platform.


### PR DESCRIPTION
Hi there,

I've spotted a typo in the doc, and took the liberty of fixing it.  Judging by similar commits (e.g. e8ba38511bbf85309430ea2eca7520bb88e142cf), the .adoc seems to be the only format needed by Antora, but please pardon me if I'm omitted something.

HTH