### PR TITLE
Add BB docs to the project

### DIFF
--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -3,14 +3,17 @@ site:
   url: https://docs.decidim.org
   start_page: master@en:ROOT:index.adoc
 content:
-  edit_url: 'https://github.com/decidim/documentation/edit/{refname}/{path}'
+  edit_url: "https://github.com/decidim/documentation/edit/{refname}/{path}"
   sources:
-  - url: &landing .
-    start_path: /en
-    branches: HEAD
-  - url: https://github.com/decidim/decidim
-    start_path: docs
-    branches: develop
+    - url: &landing .
+      start_path: /en
+      branches: HEAD
+    - url: https://github.com/decidim/decidim
+      start_path: docs
+      branches: develop
+    - url: https://github.com/decidim/decidim-bulletin-board
+      start_path: docs
+      branches: develop
 ui:
   bundle:
     url: https://github.com/decidim/documentation-antora-ui/releases/download/v0.3/ui-bundle.zip
@@ -19,6 +22,6 @@ ui:
 asciidoc:
   attributes:
     kroki-fetch-diagram: true
-    page-pagination: ''
+    page-pagination: ""
   extensions:
     - asciidoctor-kroki


### PR DESCRIPTION
This PR adds the BB documentation to the project, as shown in the screenshot.

![imagen](https://user-images.githubusercontent.com/453545/107356680-63ccb000-6ad1-11eb-8e94-e3f26895315b.png)

⚠️ We should merge [the PR #99 on the BB repo](decidim/decidim-bulletin-board/pull/99) before merging this, as it depends on the existence of the `docs` folder in that repo.
