### PR TITLE
Update social-contract.adoc

### DIFF
--- a/en/modules/understand/pages/social-contract.adoc
+++ b/en/modules/understand/pages/social-contract.adoc
@@ -7,41 +7,41 @@ You can also read Decidim's Social Contract in other languages: xref:understand:
 If you want to translate it to your own language please https://decidim.org/contact[contact us].
 ====
 
-Code for democratic guarantees and open collaboration
+All members and partners of the Decidim project must endorse and follow a Social Contract.
 
-This is the social contract that all members of the Decidim community are committed to follow.
+By signing this Social Contract, any individual, institution or social group of any kind commits to fulfill the principles established here when using, developing and participating in the community of Decidim.
 
-By signing this Social Contract, any individual, institution or social group of any kind, commits to fulfill the principles established here when using, developing and participating in the community of Decidim.
+== Free Software and open content
 
-== Free software and open content
+Decidim will always remain free and open to collaboration, without legal or technical obstacles for the use, copy and modification. To ensure this we use a set of licenses:
 
-The code of the platform, along with the modules, libraries or any other code that is developed for its functioning and deployment, will always be Free Open Source Software with an https://www.gnu.org/licenses/agpl-3.0.en.html[Affero GPLv3 license or later versions] whenever the code is newly developed and with licenses that are compatible with the above one when code re-used.
+ - https://www.gnu.org/licenses/agpl-3.0.en.html[Affero GPLv3 license or later versions] or compatible licenses for the code of the platform, the modules, libraries and any other code that is developed or re-used for its functioning and deployment.
+ - https://creativecommons.org/licenses/by-sa/4.0/legalcode[Creative Commons By-SA license] for the content (text, graphics, images, fonts, audio, video or other design elements). 
+ -  http://opendatacommons.org/licenses/odbl[Open Data Commons Open Database License] for the data available through the platform, especially all data that can be collected in a systematic way through scrappers or other techniques of massive consultation. These data should be published under standardized and accessible formats (such as CSV, JSON, etc.) and, whenever possible, with tools that facilitate the analysis and visualization of data.
+ 
+The content, data, APIs and/or any other interfaces that are deployed to interact with any type of user must follow open and interoperable standards (ex. OpenID, RSS, OStatus, etc.), always tending to maximize their integration with the most widely used open standards.
 
-Likewise, the content, data, APIs and/or any other interfaces that are deployed to interact with any type of user must follow open and interoperable standards (ex. OpenID, RSS, OStatus, etc.), always tending to maximize their integration with the most widely used open standards.
-
-In order to maximize transparency and citizen collaboration in participatory processes, organs and mechanisms, the content, text, graphics, fonts, audio, video or other design elements will be published under a https://creativecommons.org/licenses/by-sa/4.0/legalcode[Creative Commons By-SA].
-
-The data available through the platform, especially all data that can be collected in a systematic way through scrappers or other techniques of massive consultation, will be published and licensed under http://opendatacommons.org/licenses/odbl[Open Data Commons Open Database License], published under standardized and accessible formats (such as CSV, JSON, etc.) and, whenever possible, with tools that facilitate the analysis and visualization of data.
 
 == Transparency, traceability and integrity
 
-The platform, and its current or future configuration, development, deployment and use must ensure and maximize, at all times, the transparency, traceability and integrity of documents, proposals, debates, decisions, or any other object, mechanism or participatory process.
+The content of participation will always remain transparent, traceable and integral. 
 
-By _transparency_ we understand that all data related to all such participatory mechanisms and processes are available for download, analysis and treatment, following the most demanding standards and formats to share information (accessibility, multi-format, etc.).
+  - _Transparent_ means that all the content must be accessible and downloadable. This should never be applied to personal data or against the defense of the privacy of the people participating in the platform.
 
-Transparency is a necessary condition for monitoring of participatory processes and mechanisms, but should never, in any case, be applied for the treatment of personal data or against the defense of the privacy of the people participating in the platform.
+  - _Traceable_ means that it should always be possible to fully track backward (past) and forward (future) each object of participation or decision (proposal, plan, regulation, etc.) included in a process. The platform must at all times show how, why, by whom and with what guarantees a certain type of object of a participatory process was dismissed, approved or blocked.
 
-We understand by _traceability_ the ability to fully track backward (past) and forward (future) what happened to the proposals, plans, regulations, or any other object of participation or decision included in a process or mechanism. The platform must at all times show how, why, by whom and with what guarantees a certain type of object of a participatory process was dismissed, approved or blocked.
+  - _Integral_ means that the content needs to be displayed without having been manipulated. Any modification (if required) must be registered and be accessible and auditable.
 
-We understand by _integrity_ the authenticity of a specific content, and ensuring that it has not been tampered with or altered without this modification being clearly recorded and visibly verifiable and auditable. The goal of integrity is to avoid manipulation of proposals or results of participatory processes or mechanisms.
 
-== Equal opportunities and quality indicators
+== Equal opportunities, democratic quality and inclusiveness
 
-Alongside the guarantees previously defined, the platform promises to ensure equal opportunities for all people, as well as for their proposals or other contributions the platform might host. The platform will offer equal starting opportunities to all participatory objects (proposals, debates, etc.) for them to be viewed, discussed, commented, evaluated or treated without discrimination of any kind. In this sense, the digital identity of the users of the platform will always be personal and not transferable, the verification that confers decision rights on the platform should also be unique, and it is the administrative entity in charge of the platform who should be responsible for ensuring non-impersonation of a person or entity.
+The platform promises to ensure equal opportunities for all people, as well as for their proposals or other contributions the platform might host. 
 
-The platform should promote, with the aim of ensuring its democratic quality, the use of quality indicators developed on the basis of the data obtained from participatory processes, mechanism and user activity. Sharing of the setting of the different components as well as open data will be promoted for the definition of these indicators
+All participatory objects (proposals, debates, etc.) should be equally viewed, discussed, commented, evaluated or treated without discrimination of any kind.
 
-Equality in political participation of citizens is one of the fundamental principles of any democratic system and the platform, not only has to ensure equal opportunities with respect to the uses and functions, but also the access right. In this sense the entity in charge of the platform assumes the commitment to promote actions that advance in the direction of providing access and support to the platform for all citizens alike universally Giving tools and resources appropriate to the platform is available to anyone who wants to use.
+The platform must comply with accessibility standards, its use must favour the integration of online and offline participation and organizations must deploy the means for mediation and training of participants.
+the unicity and democratic rights of participants must be preserved (meaning there cannot be two verified users corresponding to the same individual with democratic rights and all participants with such rights must be verifiable).
+
 
 == Data confidentiality
 
@@ -49,7 +49,7 @@ The confidentiality and privacy of the personal data that people might provide t
 
 == Accountability and responsibility
 
-A commitment to citizens shall be taken to respond to all queries and contributions in the shortest time possible. A commitment shall also be adopted to follow-up the results of participatory processes and to respond to those demands which specifically request it. Finally, a commitment shall be taken to study the incorporation of indicators to monitor the participation processes once they are finalized, in order to systematically evaluate its implementation.
+Institutions using Decidim must commit to respond to all queries and contributions in the shortest time possible. A commitment shall also be adopted to follow-up the results of participatory processes and to respond to those demands which specifically request it. Finally, a commitment shall be taken to study the incorporation of indicators to monitor the participation processes once they are finalized, in order to systematically evaluate its implementation.
 
 == Continuous improvement and inter-institutional collaboration
 


### PR DESCRIPTION
Information about the Social Contract found [here](https://docs.decidim.org/en/whitepaper/decidim-a-brief-overview/) (The social contract section) is merged into [here](https://docs.decidim.org/en/understand/social-contract/) for clarity purposes, so it can be deleted from the first link. I suppose that the author should be mentioned in the merged information.