### PR TITLE
Add '[CI] Antora' workflow 

### DIFF
--- a/.github/workflows/ci_antora.yml
+++ b/.github/workflows/ci_antora.yml
@@ -1,0 +1,24 @@
+name: "[CI] Antora"
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    paths:
+      - "*"
+
+jobs:
+  check:
+    name: Run Antora CI
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Use Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: '14.x'
+      - name: Install dependencies
+        run: npm install
+      - name: Run build script
+        run: npm build
+


### PR DESCRIPTION
Adds a new workflow for PRs, so we don't merge errors and warnings from Antora detected by the build command. 