### PR TITLE
Use `create_admin` task for system admin

### DIFF
--- a/en/modules/admin/pages/system.adoc
+++ b/en/modules/admin/pages/system.adoc
@@ -10,14 +10,14 @@ image::system-log_in.png[system panel log in]
 
 == 1. Create an admin account
 
-For accessing in this dashboard, you'll need to create a system admin account from your terminal:
+For logging in to this dashboard, you'll need to create a system admin account from your terminal:
 
 [source, console]
 ....
 bin/rails decidim_system:create_admin
 ....
 
-You'll be asked for an email and a password. For security, the password'll not get displayed back at you and you'll need to confirm it. 
+You'll be asked for an email and a password. For security, the password will not get displayed back at you and you'll need to confirm it. 
 
 == 2. Access the Dashboard
 

--- a/en/modules/admin/pages/system.adoc
+++ b/en/modules/admin/pages/system.adoc
@@ -10,7 +10,7 @@ image::system-log_in.png[system panel log in]
 
 == 1. Create an admin account
 
-For accessing in this dashboard, you'll need to create a system admin account from the console. , as the instructions that you have in your `README.md` file:
+For accessing in this dashboard, you'll need to create a system admin account from your terminal:
 
 [source, console]
 ....

--- a/en/modules/admin/pages/system.adoc
+++ b/en/modules/admin/pages/system.adoc
@@ -1,6 +1,6 @@
 = System 
 
-Every Decidim is multi-tenant by default. That means that you can have multiple organizations inside of your same installation. This is being used for instance for the Barcelona and Girona Provincials Governments, for offering Decidim installations to many small cities, or by the City of Barcelona, for giving service to lots of organizations (NGOs, cooperatives, etc).
+Every Decidim is multi-tenant by default. That means that you can have multiple organizations inside of your same installation. This is being used for instance for the Barcelona and Girona Provincials Governments, for offering Decidim installations to many small cities, or by the City of Barcelona, for giving service to lots of organizations (NGOs, cooperatives, etc). For instance, you can have 
 
 Even if you only have one Organization you also need to create one through the System Panel. It's available after you've installed Decidim, at `/system`. For instance if you domain is `example.org`, then it should be available at `http://example.org/system`.
 
@@ -10,35 +10,18 @@ image::system-log_in.png[system panel log in]
 
 == 1. Create an admin account
 
-For accessing in this dashboard, you'll need to create a system admin account with the Rails console, as the instructions that you have in your `README.md` file:
+For accessing in this dashboard, you'll need to create a system admin account from the console. , as the instructions that you have in your `README.md` file:
 
-Open a console:
 [source, console]
 ....
-bin/rails console
+bin/rails decidim_system:create_admin
 ....
 
-Then create the systems' admin:
-
-[source, ruby]
-....
-user = Decidim::System::Admin.new(email: <email>, password: <password>, password_confirmation: <password>)
-user.save!
-....
-
-So for example, if your email is `system@decidim.org` and your password `decidim123456` that'd be:
-
-[source, ruby]
-....
-user = Decidim::System::Admin.new(email: 'system@decidim.org', password: 'decidim123456', password_confirmation: 'decidim123456')
-user.save!
-....
-
-IMPORTANT: Please don't use this password, is really insecure!
+You'll be asked for an email and a password. For security, the password'll not get displayed back at you and you'll need to confirm it. 
 
 == 2. Access the Dashboard
 
-After you've logged in, you'll see an empty dashboard: 
+With the email and password that you've added in the past step, you'll be able to log in. After you've logged in, you'll see an empty dashboard: 
 
 image::system-dashboard.png[system empty dashboard]
 
@@ -59,7 +42,6 @@ TIP: Please mind that some of these fields can't change through the System Form,
 |Reference prefix
 |Required
 |The reference prefix is used to uniquely identify resources across all organizations. It's for identifying different resources inside of Decidim. For instance, "BCN". You can change how it's created this reference through xref:configure:initializer.adoc[Decidim's initializer] (see **Custom resource reference**).
-
 
 |Host
 |Required

--- a/en/modules/admin/pages/system.adoc
+++ b/en/modules/admin/pages/system.adoc
@@ -1,6 +1,6 @@
 = System 
 
-Every Decidim is multi-tenant by default. That means that you can have multiple organizations inside of your same installation. This is being used for instance for the Barcelona and Girona Provincials Governments, for offering Decidim installations to many small cities, or by the City of Barcelona, for giving service to lots of organizations (NGOs, cooperatives, etc). For instance, you can have 
+Every Decidim is multi-tenant by default. That means that you can have multiple organizations inside of your same installation. This is being used for instance for the Barcelona and Girona Provincials Governments, for offering Decidim installations to many small cities, or by the City of Barcelona, for giving service to lots of organizations (NGOs, cooperatives, etc).
 
 Even if you only have one Organization you also need to create one through the System Panel. It's available after you've installed Decidim, at `/system`. For instance if you domain is `example.org`, then it should be available at `http://example.org/system`.
 


### PR DESCRIPTION
While reviewing https://github.com/decidim/decidim/pull/9349, I have seen that we didn't update the instructions to make easier the creation of the first system admin (from https://github.com/decidim/decidim/pull/8010). This PR fixed that. 