### PR TITLE
Fix typo in the follows documentation

### DIFF
--- a/en/modules/admin/pages/features/follows.adoc
+++ b/en/modules/admin/pages/features/follows.adoc
@@ -24,4 +24,4 @@ image:button_stop_following.png[Stop following button]
 Administrators by default follow all the new spaces that are created in the Decidim platform.
 
 A participant can also follow another participants. This is public and it's visible in the profile sections
-xref:features/my_public_profile/follows.adoc[follows] and xref:features/my_public_profile/follows.adoc[followers].
+xref:features/my_public_profile/follows.adoc[follows] and xref:features/my_public_profile/followers.adoc[followers].


### PR DESCRIPTION
There is a small typo in the follows documentation link. This fixes that.