### PR TITLE
Fix broken links to fix the build

### DIFF
--- a/en/modules/admin/pages/components/accountability.adoc
+++ b/en/modules/admin/pages/components/accountability.adoc
@@ -1,0 +1,10 @@
+= Accountability
+
+The Accountability component allows people to follow project implementations. It works like a project management system built into the platform. It offers the following features:
+
+* creating results that represent projects to be implemented
+* subdividing results into projects or sub-projects
+* defining and applying progress in implementation statuses (0% to 100% implemented) around their implementation
+* displaying the extent of the results’ implementation grouped by categories and scopes
+
+Results, projects and statuses can be updated through a CVS, or manually by the administration interface.

--- a/en/modules/admin/pages/components/sortitions.adoc
+++ b/en/modules/admin/pages/components/sortitions.adoc
@@ -1,0 +1,3 @@
+= Sortitions
+
+The Sortitions component allows to select a number of proposals (e.g. candidates for a jury) with random, yet reproducible, procedures that guarantees non-biased and uniform distributions.

--- a/en/modules/admin/pages/features/hashtags.adoc
+++ b/en/modules/admin/pages/features/hashtags.adoc
@@ -1,0 +1,5 @@
+= Hashtags
+
+Hashtags are a way to categorize content globally on the platform and make it more easily searchable through these categorizations. It allows different related contents to be easily discoverable under the same topic. Similar functionality is often used in other social media platforms.
+
+Hashtags can be set for different records within the platform, such as participatory spaces. They can also be generated for content created by the participants to allow easier discovery of the content. Some components may also allow setting suggested hashtags or specific hashtags for all records submitted by the participants.

--- a/en/modules/admin/pages/features/my_public_profile.adoc
+++ b/en/modules/admin/pages/features/my_public_profile.adoc
@@ -1,0 +1,18 @@
+= My public profile
+
+Every participant has a public profile that shows details about them and their activity on the website.
+
+To go to this section:
+
+. Sign in as a participant
+. Click in the name of the participant in the header
+. Click in "My public profile"
+
+The sections available under the public profile are:
+
+* xref:admin:features/my_public_profile/timeline.adoc[Timeline]
+* xref:admin:features/my_public_profile/activity.adoc[Activity]
+* xref:admin:features/badges.adoc[Badges]
+* xref:admin:features/my_public_profile/follows.adoc[Follows]
+* xref:admin:features/my_public_profile/followers.adoc[Followers]
+* xref:admin:features/my_public_profile/groups.adoc[Groups]

--- a/en/modules/admin/pages/features/my_public_profile/badges.adoc
+++ b/en/modules/admin/pages/features/my_public_profile/badges.adoc
@@ -1,0 +1,5 @@
+= Badges
+
+The public profile's badges shows which badges the participant has accumulated and what their current level is for each badge.
+
+More information about badges is available on the xref:admin:features/badges.adoc[Badges feature page].

--- a/en/modules/admin/pages/features/my_public_profile/followers.adoc
+++ b/en/modules/admin/pages/features/my_public_profile/followers.adoc
@@ -1,0 +1,3 @@
+= Followers
+
+The followers section contains a list of participants and groups that are following the participant that the profile belongs to.

--- a/en/modules/admin/pages/features/my_public_profile/follows.adoc
+++ b/en/modules/admin/pages/features/my_public_profile/follows.adoc
@@ -1,0 +1,3 @@
+= Follows
+
+The follows section contains a list of participants and groups the participant is currently following. By following another participant or a group on the platform, the participant will receive notifications about the activity done by those other participants or groups on the platform. Some participants may also require that they need to be following the other participant before they can exchange private messages with each other.

--- a/en/modules/admin/pages/features/my_public_profile/groups.adoc
+++ b/en/modules/admin/pages/features/my_public_profile/groups.adoc
@@ -1,0 +1,3 @@
+= Groups
+
+The groups section contains all the groups that the user belongs to. More information about the groups feature is available at the xref:admin:features/badges.adoc[User groups page].

--- a/en/modules/admin/pages/features/my_public_profile/timeline.adoc
+++ b/en/modules/admin/pages/features/my_public_profile/timeline.adoc
@@ -1,0 +1,3 @@
+= Timeline
+
+The timeline view displays the participants activity on the website, including the activity items that should be only visible to the participant currently logged in. This section is not visible to any other user than the participant themselves because it can also contain items that should be visible only to that participant.

--- a/en/modules/admin/pages/features/my_public_profile/tmp_notifications.adoc
+++ b/en/modules/admin/pages/features/my_public_profile/tmp_notifications.adoc
@@ -1,0 +1,5 @@
+= Notifications
+
+In this section participants can see the notifications that the system has sent to them. For instance, if the participant is followign a participatory space or a proposal, they get related notifications about the actions that happen in these sections of the platform.
+
+This section can be accessed through the bell icon in the header bar of the platform. The bell icon shows highlighted as active when there are notifications and dimmer when there are no new notifications for the user right now.

--- a/en/modules/admin/pages/features/search.adoc
+++ b/en/modules/admin/pages/features/search.adoc
@@ -1,0 +1,3 @@
+= Search engine
+
+*The search engine* allows participants to perform searches across all of the platform’s indexable content, both generally and specifically, by searching within a specific participatory process or inside its components (proposals, results, etc.), through advanced searches.

--- a/en/modules/admin/pages/features/share.adoc
+++ b/en/modules/admin/pages/features/share.adoc
@@ -1,0 +1,3 @@
+= Share
+
+Different content on the platform can be easily shared through the share links available on the site. The share links allow easier sharing to different social media services that can be configured for Decidim through the configuration files.

--- a/en/modules/admin/pages/features/statistics.adoc
+++ b/en/modules/admin/pages/features/statistics.adoc
@@ -1,0 +1,3 @@
+= Statistics
+
+Decidim provides general statistics about the whole platform and different participatory spaces can also provide statistics related to that participatory space only. These are generic numbers that indicate the website activity and may also encourage other people to join the platform as they see it being popular.


### PR DESCRIPTION
To get the build fixed, I am fixing several missing link targets in this PR.

The content should be considered as a base for those pages, not 100% ready documentation. This PR is only to fix the broken links in the documentation, not to document them perfectly.

My main goal is to get the GitHub build fixed so that we can release a new version of the documentation through the automation. Related issues in other repositories:

Related to 
- decidim/decidim#9665
- decidim/decidim-bulletin-board#289