### PR TITLE
Ensure the CI test error log is not empty

### DIFF
--- a/bin/test
+++ b/bin/test
@@ -4,7 +4,7 @@ stderrlog=$(mktemp)
 
 npm run build 2> $stderrlog
 
-if [ -e "$stderrlog" ];
+if [ -e "$stderrlog" ] && [ -s "$stderrlog" ];
 then
   cat $stderrlog
   exit 1

--- a/en/modules/ROOT/pages/index.adoc
+++ b/en/modules/ROOT/pages/index.adoc
@@ -17,4 +17,3 @@ If you want to make changes to the source code, we have documentation for xref:d
 If you are an organisation who wants to use Decidim, or a developer who is interested in collaborating on the software, please https://decidim.org/contact[get in touch].
 
 Decidim is a community effort, as such if you find any errors on these guides please let us know at hola [at] decidim [dot] org. Every help is welcome. If you've a GitHub user then you can even propose changes to this website with the Edit link on every page.
-


### PR DESCRIPTION
The build was failing in case the error log file existed but was completely empty.

After calling `mktemp` the file exists but it will be empty in case there were no errors.

This fixes the issue and should also fix the build.