### PR TITLE
Update incorrect link to groups

### DIFF
--- a/en/modules/admin/pages/features/my_public_profile/groups.adoc
+++ b/en/modules/admin/pages/features/my_public_profile/groups.adoc
@@ -1,3 +1,3 @@
 = Groups
 
-The groups section contains all the groups that the user belongs to. More information about the groups feature is available at the xref:admin:features/badges.adoc[User groups page].
+The groups section contains all the groups that the user belongs to. More information about the groups feature is available at the xref:admin:features/my_account/groups.adoc[User groups page].


### PR DESCRIPTION
When I was reviewing the docs I noticed that this link was going to the wrong place - I believe it should go to https://docs.decidim.org/en/develop/admin/features/my_account/groups.

I _think_ this should fix it but I am not overly familiar with the linking strategy in your docs!