### PR TITLE
Change the commit user for the trigger build command

### DIFF
--- a/.github/workflows/trigger_build.yml
+++ b/.github/workflows/trigger_build.yml
@@ -12,3 +12,5 @@ jobs:
           skip_dirty_check: true
           commit_message: "Trigger build"
           commit_options: "--allow-empty"
+          commit_user_name: decidim-bot
+          commit_user_email: decidim-bot@users.noreply.github.com


### PR DESCRIPTION
In order to try to fix the "trigger build" action in this repository, I would like to try to change the committing user to `decidim-bot` which is excluded from the branch protection rules currently. The branch protection rules are making this workflow to fail currently.

Right now when we try to run the "trigger build" action (automatically through `decidim/decidim` or manually by triggering it from the actions), we are getting the following error:

```
[develop 6e1e4a6] Trigger build
 Author: decidim-bot <decidim-bot@users.noreply.github.com>
INPUT_TAGGING_MESSAGE: 
No tagging message supplied. No tag will be added.
INPUT_PUSH_OPTIONS: 
remote: error: GH006: Protected branch update failed for refs/heads/develop.        
remote: error: Required status check "netlify/decidim-documentation/deploy-preview" is expected. You're not authorized to push to this branch. Visit https://docs.github.com/articles/about-protected-branches/ for more information.        
To https://github.com/decidim/documentation
 ! [remote rejected] develop -> develop (protected branch hook declined)
error: failed to push some refs to 'https://github.com/decidim/documentation'
Error: Invalid status code: 1
    at ChildProcess.<anonymous> (/home/runner/work/_actions/stefanzweifel/git-auto-commit-action/v4/index.js:17:19)
    at ChildProcess.emit (node:events:527:28)
    at maybeClose (node:internal/child_process:1092:16)
    at Process.ChildProcess._handle.onexit (node:internal/child_process:302:5) {
  code: 1
}
Error: Invalid status code: 1
    at ChildProcess.<anonymous> (/home/runner/work/_actions/stefanzweifel/git-auto-commit-action/v4/index.js:17:19)
    at ChildProcess.emit (node:events:[52](https://github.com/decidim/documentation/actions/runs/4382598088/jobs/7671828643#step:3:53)7:28)
    at maybeClose (node:internal/child_process:1092:16)
    at Process.ChildProcess._handle.onexit (node:internal/child_process:302:5)
```

Example job run that failed:
https://github.com/decidim/documentation/actions/runs/4382598088/jobs/7671828643

Note that it is currently not possible to exclude the GitHub actions user from the branch protection rules but this feature has been requested by the GitHub community:
community/community#13836

This is why I am suggesting to change the committing user account to try to fix this issue.