### PR TITLE
Add the personal access token configuration to the trigger build action

### DIFF
--- a/.github/workflows/trigger_build.yml
+++ b/.github/workflows/trigger_build.yml
@@ -7,6 +7,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2.0.0
+        with:
+          token: ${{ secrets.WORKFLOW_PAT }}
       - uses: stefanzweifel/git-auto-commit-action@v4
         with:
           skip_dirty_check: true


### PR DESCRIPTION
#114 did not fix the trigger build action.

We will also need to add a personal access token (PAT) to the trigger build action for it to work for protected branches as explained here:
https://github.com/stefanzweifel/git-auto-commit-action#push-to-protected-branches

> ### Push to protected branches
> If your repository uses [protected branches](https://help.github.com/en/github/administering-a-repository/configuring-protected-branches) you have to make some changes to your Workflow for the Action to work properly: You need a Personal Access Token and you either have to allow force pushes or the Personal Access Token needs to belong to an Administrator.
>
> First, you have to create a new [Personal Access Token (PAT)](https://github.com/settings/tokens/new), store the token as a secret in your repository and pass the new token to the [actions/checkout](https://github.com/actions/checkout#usage) Action step.
>
> ```
> - uses: actions/checkout@v3
>   with:
>     token: ${{ secrets.PAT }}
> ```

I will create this PR as a draft until we have someone with access to the "decidim-bot" user to configure its personal access token for this repository.

Before this can be merged, the following has to happen:
1. Create a personal access token for the `decidim-bot` user
2. Configure it to the repository secrets of this repository with name `WORKFLOW_PAT`