### PR TITLE
Update the checkout action of trigger build to v3

### DIFF
--- a/.github/workflows/trigger_build.yml
+++ b/.github/workflows/trigger_build.yml
@@ -6,7 +6,7 @@ jobs:
     name: Trigger build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2.0.0
+      - uses: actions/checkout@v3
         with:
           token: ${{ secrets.WORKFLOW_PAT }}
       - uses: stefanzweifel/git-auto-commit-action@v4


### PR DESCRIPTION
I started this PR to try to fix the broken "Trigger build" workflow but this was not the cause. The problem was that the PAT had to be approved from the organization settings before it being active.

Anyways, it would be good to update this.