### PR TITLE
Update the Antora cache during deploys

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,3 +1,6 @@
+[build]
+  command = "npm run build -- --fetch"
+
 [build.environment]
   NODE_VERSION = "16.14.2"
   BUILD_ONLY = "true"


### PR DESCRIPTION
I have noticed that lately the docs site is not updating although the build pipelines are correctly running. At `decidim/decidim` we are triggering the correct workflow which then adds the deployment commit in this repository which triggers the build at Netlify.

But the problem is that Antora caches the git repositories and therefore I think the content is not updating properly, as documented at:
- https://docs.antora.org/antora/latest/cache/
- https://docs.antora.org/antora/latest/playbook/runtime-fetch/

Especially form the second link

> The first time Antora runs, it caches any remote content sources git repositories and UI bundles. On subsequent runs, Antora resolves these resources in the cache folder, **effectively running offline.**

So I think we need to pass the `--fetch` option in order to ensure that the cache is updated every time the content is deployed. Otherwise it may take a long time for the cache to disappear and the content to update properly.