### PR TITLE
Use `node-version-file` configuration for the CI

### DIFF
--- a/.github/workflows/ci_antora.yml
+++ b/.github/workflows/ci_antora.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: '14.x'
+          node-version-file: ".node-version"
       - name: Install dependencies
         run: npm install
       - name: Run test script


### PR DESCRIPTION
Noticed that we are statically defining the Node version for the CI but we can use the `node-version-file` configuration that was added to `actions/setup-node` at v2.5.0 (actions/setup-node#338):

https://github.com/actions/setup-node/releases/tag/v2.5.0

One less thing to maintain.