### PR TITLE
WIP: Add supports page & clarity on endorsements v supports

### DIFF
--- a/en/modules/ROOT/nav.adoc
+++ b/en/modules/ROOT/nav.adoc
@@ -136,6 +136,7 @@
 *** xref:admin:features/search.adoc[Search]
 *** xref:admin:features/share.adoc[Share]
 *** xref:admin:features/statistics.adoc[Statistics]
+*** xref:admin:features/supports.adoc[Supports]
 *** xref:admin:features/versions.adoc[Versions]
 ** xref:admin:newsletters.adoc[Newsletters]
 ** xref:admin:global_moderations.adoc[Global moderations]

--- a/en/modules/admin/pages/features/supports.adoc
+++ b/en/modules/admin/pages/features/supports.adoc
@@ -8,4 +8,5 @@ This is done through the button in the sidebar. Administrators can enable or dis
 
 Supports differ from :xref:endorsements.adoc[] in the following ways:
 * Supports can be made private (hidden from public view) whereas endorsements are always public
-* Supports are counted as a formal vote, whereas endorsements are considered a 'like' (as used on social networks)
+* Supports are counted as a formal vote, whereas endorsements are considered a public show of support, similar to a 'like' as used on social networks
+* Supports are available on non-voting areas of Dedicim such as blog posts

--- a/en/modules/admin/pages/features/supports.adoc
+++ b/en/modules/admin/pages/features/supports.adoc
@@ -6,7 +6,7 @@ This is done through the button in the sidebar. Administrators can enable or dis
 
 == Supports v endorsements
 
-Supports differ from :xref:endorsements.adoc[] in the following ways:
+Supports differ from :xref:features/endorsements.adoc[endorsements] in the following ways:
 * Supports can be made private (hidden from public view) whereas endorsements are always public
 * Supports are counted as a formal vote, whereas endorsements are considered a public show of support, similar to a 'like' as used on social networks
 * Supports are available on non-voting areas of Dedicim such as blog posts

--- a/en/modules/admin/pages/features/supports.adoc
+++ b/en/modules/admin/pages/features/supports.adoc
@@ -1,0 +1,11 @@
+= Supports
+
+Through supports, participants can vote for a particular content, for instance, a proposal.
+
+This is done through the button in the sidebar. Administrators can enable or disable them by step in a given participatory process, and they can also define permissions with authorizations.
+
+== Supports v endorsements
+
+Supports differ from :xref:endorsements.adoc[] in the following ways:
+* Supports can be made private (hidden from public view) whereas endorsements are always public
+* Supports are counted as a formal vote, whereas endorsements are considered a 'like' (as used on social networks)


### PR DESCRIPTION
This PR adds to the Features section a page which explains Supports (see [chat on Matrix](https://matrix.to/#/!WbkoamENosPmKRcBfm:matrix.org/$fWqC3A7w6JPd9HTUFOhU2a9THGxxT5MC9UVtW76lc7M?via=matrix.org&via=matrix.platta.at&via=privchat.eu))

It also clarifies the difference between supports and endorsements.