### PR TITLE
Fix typo in accountability doc

### DIFF
--- a/docs/en/modules/admin/pages/components/accountability.adoc
+++ b/docs/en/modules/admin/pages/components/accountability.adoc
@@ -7,4 +7,4 @@ The Accountability component allows people to follow project implementations. It
 * defining and applying progress in implementation statuses (0% to 100% implemented) around their implementation
 * displaying the extent of the results’ implementation grouped by categories and scopes
 
-Results, projects and statuses can be updated through a CVS, or manually by the administration interface.
+Results, projects and statuses can be updated through a CSV (comma-separated values), or manually by the administration interface.


### PR DESCRIPTION
A typo in the accountability docs was found by @RCheesley in the Element chat, so this PR fixes that 