### PR TITLE
Fix details in Notifications list

### DIFF
--- a/docs/en/modules/admin/pages/features/notifications.adoc
+++ b/docs/en/modules/admin/pages/features/notifications.adoc
@@ -23,105 +23,105 @@ Below is an exhaustive list of actions that trigger notifications to participant
 
 [cols="7,2,1,1,1"]
 |============================================================================================================================================================================
-| Action                                                                                | Feature                                          | Follower | Affected user   | Administrator
+| Action                                                                                | Feature                                                    | Follower | Affected user   | Administrator
 
-| A new attachment has been created                                                     | Admin                                            | ✅       | ❌              | ❌
-| An admin requested an export                                                          | Admin                                            | ❌       | ❌              | ✅
-| A component has been published in a participatory space                               | Admin                                            | ✅       | ❌              | ❌
-| A participant has tried to verify themself with the data of another participant       | Verifications                                    | ❌       | ❌              | ✅
-| An administrator moderated a resource because it has been reported                    | Moderation                                       | ❌       | ✅              | ❌
-| A resource has been reported                                                          | Moderation                                       | ❌       | ❌              | ✅
-| A user confirms the registration (if welcome notification is enabled)                 | User                                             | ❌       | ✅              | ❌
-| A user earned a badge (if badges are enabled)                                         | User                                             | ❌       | ✅              | ❌
-| A user has reached a new badge level (if badges are enabled)                          | User                                             | ❌       | ✅              | ❌
-| A user has been officialized                                                          | User                                             | ❌       | ❌              | ✅
-| A user asked their data export                                                        | User                                             | ❌       | ✅              | ❌
-| A user I follow endorsed a resource                                                   | User                                             | ✅       | ❌              | ❌
-| A public profile has been updated                                                     | User                                             | ✅       | ❌              | ❌
+| A new attachment has been created                                                     | Admin                                                      | ✅       | ❌              | ❌
+| An admin requested an export                                                          | Admin                                                      | ❌       | ❌              | ✅
+| A component has been published in a participatory space                               | Admin                                                      | ✅       | ❌              | ❌
+| A participant has tried to verify themself with the data of another participant       | Verifications                                              | ❌       | ❌              | ✅
+| An administrator moderated a resource because it has been reported                    | Moderation                                                 | ❌       | ✅              | ❌
+| A resource has been reported                                                          | Moderation                                                 | ❌       | ❌              | ✅
+| A user confirms the registration (if welcome notification is enabled)                 | User                                                       | ❌       | ✅              | ❌
+| A user earned a badge (if badges are enabled)                                         | User                                                       | ❌       | ✅              | ❌
+| A user has reached a new badge level (if badges are enabled)                          | User                                                       | ❌       | ✅              | ❌
+| A user has been officialized                                                          | User                                                       | ❌       | ❌              | ✅
+| A user asked their data export                                                        | User                                                       | ❌       | ✅              | ❌
+| A user I follow endorsed a resource                                                   | User                                                       | ✅       | ❌              | ❌
+| A public profile has been updated                                                     | User                                                       | ✅       | ❌              | ❌
 | A new user group has been created                                                     | User groupsfootnote:user-group[If user groups are enabled] | ❌       | ❌              | ✅
-| A user group has updated its profile                                                  | User groupsfootnote:user-group[] | ❌       | ❌              | ✅
-| A user has been invited to join a user group                                          | User groupsfootnote:user-group[] | ❌       | ✅              | ❌
-| A user has been promoted as group admin                                               | User groupsfootnote:user-group[] | ❌       | ✅              | ❌
-| A user requested to join the user group                                               | User groupsfootnote:user-group[] | ❌       | ✅              | ❌
-| A user request has been accepted to join the user group                               | User groupsfootnote:user-group[] | ❌       | ✅              | ❌
-| A user request to join the user group has been rejected                               | User groupsfootnote:user-group[] | ❌       | ✅              | ❌
-| The group admin has been demoted                                                      | User groupsfootnote:user-group[] | ❌       | ✅              | ❌
-| The user has been removed from the group                                              | User groupsfootnote:user-group[] | ❌       | ✅              | ❌
-| An admin of the assembly has added you as one of its members                          | Assemblies                                       | ❌       | ✅              | ❌
-| You have been assigned a role for the assembly                                        | Assemblies                                       | ❌       | ✅              | ❌
-| You have been assigned a role for the participatory process                           | Processes                                        | ❌       | ✅              | ❌
-| The phases dates have been updated                                                    | Processes                                        | ✅       | ❌              | ❌
-| A new phase has been activated                                                        | Processes                                        | ✅       | ❌              | ❌
-| You have been assigned a role for the conference                                      | Conferences                                      | ❌       | ✅              | ❌
-| The registration to the conference has been confirmed                                 | Conferences                                      | ❌       | ✅              | ❌
-| The registration for the conference is open                                           | Conferences                                      | ✅       | ❌              | ❌
-| The conference occupied slots are over X%                                             | Conferences                                      | ❌       | ❌              | ✅
-| The conference is taking place in 2 days                                              | Conferences                                      | ✅       | ❌              | ❌
-| The conference has been updated                                                       | Conferences                                      | ✅       | ❌              | ❌
-| The election is now active for the participatory space                                | Elections                                        | ✅       | ❌              | ❌
-| You are added as a trustee for the election                                           | Elections                                        | ❌       | ✅              | ❌
-| An admin has added you as trustee                                                     | Elections                                        | ❌       | ✅              | ❌
-| Your vote was accepted                                                                | Elections                                        | ❌       | ✅              | ❌
-| You have been assigned a role of the Polling Station                                  | Elections                                        | ❌       | ✅              | ❌
-| Here is your Access Code                                                              | Elections                                        | ❌       | ✅              | ❌
-| A user I follow created an initiative                                                 | Initiatives                                      | ✅       | ❌              | ❌
-| My initiative has been created                                                        | Initiatives                                      | ❌       | ✅              | ❌
-| A user I follow endorsed an initiative                                                | Initiatives                                      | ✅       | ❌              | ❌
-| A user sent their initiative to technical validation                                  | Initiatives                                      | ❌       | ❌              | ✅
-| The initiative has changed its status                                                 | Initiatives                                      | ✅       | ✅              | ❌
-| The signatures end date for the initiative have been extended                         | Initiatives                                      | ✅       | ❌              | ❌
-| The request to be part of the promoter committee for the initiative has been accepted | Initiatives                                      | ❌       | ✅              | ❌
-| The request to be part of the promoter committee for the initiative has been rejected | Initiatives                                      | ❌       | ✅              | ❌
-| A user wants to join your initiative                                                  | Initiatives                                      | ❌       | ✅              | ❌
-| The initiative has reached the signatures threshold                                   | Initiatives                                      | ❌       | ❌              | ✅
-| Your initiative has achieved the X% of signatures                                     | Initiatives                                      | ✅       | ❌              | ❌
-| The initiative has achieved the X% of signatures                                      | Initiatives                                      | ❌       | ✅              | ❌
-| The proposal has been included in a result                                            | Accountability                                   | ✅       | ❌              | ❌
-| The result progress has been updated                                                  | Accountability                                   | ✅       | ❌              | ❌
-| A post has been published                                                             | Blogs                                            | ✅       | ❌              | ❌
-| The budget is now active                                                              | Budgets                                          | ✅       | ❌              | ❌
-| A resource has a comment                                                              | Comments                                         | ✅       | ❌              | ❌
-| A user group has left a comment on a resource                                         | Comments                                         | ✅       | ❌              | ❌
-| A user has left a comment on a resource                                               | Comments                                         | ✅       | ❌              | ❌
-| A user has replied your comment                                                       | Comments                                         | ❌       | ✅              | ❌
-| A group you belong to has been mentioned                                              | Comments                                         | ❌       | ✅              | ❌
-| You have been mentioned                                                               | Comments                                         | ❌       | ✅              | ❌
-| Your comment in has been upvoted                                                      | Comments                                         | ❌       | ✅              | ❌
-| Your comment in has been downvoted                                                    | Comments                                         | ❌       | ✅              | ❌
-| A debate has been created                                                             | Debates                                          | ✅       | ❌              | ❌
-| Debate creation is enabled for participants                                           | Debates                                          | ✅       | ❌              | ❌
-| Debate creation is no longer active                                                   | Debates                                          | ✅       | ❌              | ❌
-| The debate was closed                                                                 | Debates                                          | ✅       | ✅              | ❌
-| A meeting has been created                                                            | Meetings                                         | ✅       | ❌              | ❌
-| A meeting was closed                                                                  | Meetings                                         | ✅       | ✅              | ❌
-| A meeting was updated                                                                 | Meetings                                         | ✅       | ❌              | ❌
-| Your meeting's registration has been confirmed                                        | Meetings                                         | ❌       | ✅              | ❌
-| The allocated slots for the meeting are over X%                                       | Meetings                                         | ❌       | ❌              | ✅
-| The meeting has enabled registrations                                                 | Meetings                                         | ✅       | ❌              | ❌
-| The registration code for the meeting has been validated.                             | Meetings                                         | ❌       | ✅              | ❌
-| The meeting will start in less than 48h                                               | Meetings                                         | ✅       | ❌              | ❌
-| A new proposal has been published                                                     | Proposals                                        | ✅       | ❌              | ❌
-| Proposal creation is open                                                             | Proposals                                        | ✅       | ❌              | ❌
-| Proposal supports are open                                                            | Proposals                                        | ✅       | ❌              | ❌
-| Proposal endorsements are open                                                        | Proposals                                        | ✅       | ❌              | ❌
-| Someone has left a note on the proposal                                               | Proposals                                        | ❌       | ❌              | ✅
-| A proposal is currently being evaluated                                               | Proposals                                        | ✅       | ✅              | ❌
-| A proposal has been rejected                                                          | Proposals                                        | ✅       | ✅              | ❌
-| A proposal has been accepted                                                          | Proposals                                        | ✅       | ✅              | ❌
-| An admin has updated the scope of your proposal                                       | Proposals                                        | ❌       | ✅              | ❌
-| An admin has updated the category of your proposal                                    | Proposals                                        | ❌       | ✅              | ❌
-| A proposal has been mentioned                                                         | Proposals                                        | ❌       | ✅              | ❌
-| A user requested access as a contributor                                              | Proposal drafts                                  | ❌       | ✅              | ❌
-| You have been accepted to access as a contributor                                     | Proposal drafts                                  | ❌       | ✅              | ❌
-| You have been rejected to access as a contributor                                     | Proposal drafts                                  | ❌       | ✅              | ❌
-| A user has been rejected to access as a contributor                                   | Proposal drafts                                  | ❌       | ✅              | ❌
-| A user has been accepted to access as a contributor                                   | Proposal drafts                                  | ❌       | ✅              | ❌
-| A user withdrawn the collaborative draft                                              | Proposal drafts                                  | ❌       | ✅              | ❌
+| A user group has updated its profile                                                  | User groupsfootnote:user-group[]                           | ❌       | ❌              | ✅
+| A user has been invited to join a user group                                          | User groupsfootnote:user-group[]                           | ❌       | ✅              | ❌
+| A user has been promoted as group admin                                               | User groupsfootnote:user-group[]                           | ❌       | ✅              | ❌
+| A user requested to join the user group                                               | User groupsfootnote:user-group[]                           | ❌       | ✅              | ❌
+| A user request has been accepted to join the user group                               | User groupsfootnote:user-group[]                           | ❌       | ✅              | ❌
+| A user request to join the user group has been rejected                               | User groupsfootnote:user-group[]                           | ❌       | ✅              | ❌
+| The group admin has been demoted                                                      | User groupsfootnote:user-group[]                           | ❌       | ✅              | ❌
+| The user has been removed from the group                                              | User groupsfootnote:user-group[]                           | ❌       | ✅              | ❌
+| An admin of the assembly has added you as one of its members                          | Assemblies                                                 | ❌       | ✅              | ❌
+| You have been assigned a role for the assembly                                        | Assemblies                                                 | ❌       | ✅              | ❌
+| You have been assigned a role for the participatory process                           | Processes                                                  | ❌       | ✅              | ❌
+| The phases dates have been updated                                                    | Processes                                                  | ✅       | ❌              | ❌
+| A new phase has been activated                                                        | Processes                                                  | ✅       | ❌              | ❌
+| You have been assigned a role for the conference                                      | Conferences                                                | ❌       | ✅              | ❌
+| The registration to the conference has been confirmed                                 | Conferences                                                | ❌       | ✅              | ❌
+| The registration for the conference is open                                           | Conferences                                                | ✅       | ❌              | ❌
+| The conference occupied slots are over X%                                             | Conferences                                                | ❌       | ❌              | ✅
+| The conference is taking place in 2 days                                              | Conferences                                                | ✅       | ❌              | ❌
+| The conference has been updated                                                       | Conferences                                                | ✅       | ❌              | ❌
+| The election is now active for the participatory space                                | Elections                                                  | ✅       | ❌              | ❌
+| You are added as a trustee for the election                                           | Elections                                                  | ❌       | ✅              | ❌
+| An admin has added you as trustee                                                     | Elections                                                  | ❌       | ✅              | ❌
+| Your vote was accepted                                                                | Elections                                                  | ❌       | ✅              | ❌
+| You have been assigned a role of the Polling Station                                  | Elections                                                  | ❌       | ✅              | ❌
+| Here is your Access Code                                                              | Elections                                                  | ❌       | ✅              | ❌
+| A user I follow created an initiative                                                 | Initiatives                                                | ✅       | ❌              | ❌
+| My initiative has been created                                                        | Initiatives                                                | ❌       | ✅              | ❌
+| A user I follow endorsed an initiative                                                | Initiatives                                                | ✅       | ❌              | ❌
+| A user sent their initiative to technical validation                                  | Initiatives                                                | ❌       | ❌              | ✅
+| The initiative has changed its status                                                 | Initiatives                                                | ✅       | ✅              | ❌
+| The signatures end date for the initiative have been extended                         | Initiatives                                                | ✅       | ❌              | ❌
+| The request to be part of the promoter committee for the initiative has been accepted | Initiatives                                                | ❌       | ✅              | ❌
+| The request to be part of the promoter committee for the initiative has been rejected | Initiatives                                                | ❌       | ✅              | ❌
+| A user wants to join your initiative                                                  | Initiatives                                                | ❌       | ✅              | ❌
+| The initiative has reached the signatures threshold                                   | Initiatives                                                | ❌       | ❌              | ✅
+| Your initiative has achieved the X% of signatures                                     | Initiatives                                                | ✅       | ❌              | ❌
+| The initiative has achieved the X% of signatures                                      | Initiatives                                                | ❌       | ✅              | ❌
+| The proposal has been included in a result                                            | Accountability                                             | ✅       | ❌              | ❌
+| The result progress has been updated                                                  | Accountability                                             | ✅       | ❌              | ❌
+| A post has been published                                                             | Blogs                                                      | ✅       | ❌              | ❌
+| The budget is now active                                                              | Budgets                                                    | ✅       | ❌              | ❌
+| A resource has a comment                                                              | Comments                                                   | ✅       | ❌              | ❌
+| A user group has left a comment on a resource                                         | Comments                                                   | ✅       | ❌              | ❌
+| A user has left a comment on a resource                                               | Comments                                                   | ✅       | ❌              | ❌
+| A user has replied your comment                                                       | Comments                                                   | ❌       | ✅              | ❌
+| A group you belong to has been mentioned                                              | Comments                                                   | ❌       | ✅              | ❌
+| You have been mentioned                                                               | Comments                                                   | ❌       | ✅              | ❌
+| Your comment in has been upvoted                                                      | Comments                                                   | ❌       | ✅              | ❌
+| Your comment in has been downvoted                                                    | Comments                                                   | ❌       | ✅              | ❌
+| A debate has been created                                                             | Debates                                                    | ✅       | ❌              | ❌
+| Debate creation is enabled for participants                                           | Debates                                                    | ✅       | ❌              | ❌
+| Debate creation is no longer active                                                   | Debates                                                    | ✅       | ❌              | ❌
+| The debate was closed                                                                 | Debates                                                    | ✅       | ✅              | ❌
+| A meeting has been created                                                            | Meetings                                                   | ✅       | ❌              | ❌
+| A meeting was closed                                                                  | Meetings                                                   | ✅       | ✅              | ❌
+| A meeting was updated                                                                 | Meetings                                                   | ✅       | ❌              | ❌
+| Your meeting's registration has been confirmed                                        | Meetings                                                   | ❌       | ✅              | ❌
+| The allocated slots for the meeting are over X%                                       | Meetings                                                   | ❌       | ❌              | ✅
+| The meeting has enabled registrations                                                 | Meetings                                                   | ✅       | ❌              | ❌
+| The registration code for the meeting has been validated.                             | Meetings                                                   | ❌       | ✅              | ❌
+| The meeting will start in less than 48h                                               | Meetings                                                   | ✅       | ❌              | ❌
+| A new proposal has been published                                                     | Proposals                                                  | ✅       | ❌              | ❌
+| Proposal creation is open                                                             | Proposals                                                  | ✅       | ❌              | ❌
+| Proposal supports are open                                                            | Proposals                                                  | ✅       | ❌              | ❌
+| Proposal endorsements are open                                                        | Proposals                                                  | ✅       | ❌              | ❌
+| Someone has left a note on the proposal                                               | Proposals                                                  | ❌       | ❌              | ✅
+| A proposal is currently being evaluated                                               | Proposals                                                  | ✅       | ✅              | ❌
+| A proposal has been rejected                                                          | Proposals                                                  | ✅       | ✅              | ❌
+| A proposal has been accepted                                                          | Proposals                                                  | ✅       | ✅              | ❌
+| An admin has updated the scope of your proposal                                       | Proposals                                                  | ❌       | ✅              | ❌
+| An admin has updated the category of your proposal                                    | Proposals                                                  | ❌       | ✅              | ❌
+| A proposal has been mentioned                                                         | Proposals                                                  | ❌       | ✅              | ❌
+| A user requested access as a contributor                                              | Proposal drafts                                            | ❌       | ✅              | ❌
+| You have been accepted to access as a contributor                                     | Proposal drafts                                            | ❌       | ✅              | ❌
+| You have been rejected to access as a contributor                                     | Proposal drafts                                            | ❌       | ✅              | ❌
+| A user has been rejected to access as a contributor                                   | Proposal drafts                                            | ❌       | ✅              | ❌
+| A user has been accepted to access as a contributor                                   | Proposal drafts                                            | ❌       | ✅              | ❌
+| A user withdrawn the collaborative draft                                              | Proposal drafts                                            | ❌       | ✅              | ❌
 | An amendment has been rejected                                                        | Amendmentsfootnote:amendments[If amendments are enabled]   | ✅       | ✅              | ❌
-| An amendment has been accepted                                                        | Amendmentsfootnote:amendments[]   | ✅       | ✅              | ❌
-| An amendment has been created                                                         | Amendmentsfootnote:amendments[]   | ✅       | ✅              | ❌
-| An amendment has been promoted                                                        | Amendmentsfootnote:amendments[]   | ✅       | ✅              | ❌
-| A sortition has been created                                                          | Sortitions                                       | ✅       | ❌              | ❌
-| A survey has been opened                                                              | Surveys                                          | ✅       | ❌              | ❌
-| A survey has been closed                                                              | Surveys                                          | ✅       | ❌              | ❌
+| An amendment has been accepted                                                        | Amendmentsfootnote:amendments[]                            | ✅       | ✅              | ❌
+| An amendment has been created                                                         | Amendmentsfootnote:amendments[]                            | ✅       | ✅              | ❌
+| An amendment has been promoted                                                        | Amendmentsfootnote:amendments[]                            | ✅       | ✅              | ❌
+| A sortition has been created                                                          | Sortitions                                                 | ✅       | ❌              | ❌
+| A survey has been opened                                                              | Surveys                                                    | ✅       | ❌              | ❌
+| A survey has been closed                                                              | Surveys                                                    | ✅       | ❌              | ❌
 |============================================================================================================================================================================

--- a/docs/en/modules/admin/pages/features/notifications.adoc
+++ b/docs/en/modules/admin/pages/features/notifications.adoc
@@ -23,7 +23,7 @@ Below is an exhaustive list of actions that trigger notifications to participant
 
 [NOTE]
 ====
-Affected user's depend in the notification context. For instance it could be the author of a moderated content, a user that earns a badge, a user that has been mentioned, etc.
+Affected users depend on the notification context. For instance, it could be the author of moderated content, a user that earns a badge, a user that has been mentioned, etc.
 ====
 
 [cols="7,2,1,1,1"]

--- a/docs/en/modules/admin/pages/features/notifications.adoc
+++ b/docs/en/modules/admin/pages/features/notifications.adoc
@@ -24,104 +24,104 @@ Below is an exhaustive list of actions that trigger notifications to participant
 [options="header"]
 |============================================================================================================================================================================
 | 0.28 version                             |                                                                                       | Roles    |               |
-| Component                                | Action                                                                                | Follower | Affected user | Administrator
-| Admin                                    | A new attachment has been created                                                     | ✅     | ❌          | ❌
-|                                          | An admin requested an export                                                          | ❌     | ❌          | ✅
-|                                          | A component has been published in a participatory space                               | ✅     | ❌          | ❌
-| Verifications                            | A participant has tried to verify themself with the data of another participant       | ❌     | ❌          | ✅
-| Moderation                               | An administrator moderated a resource because it has been reported                    | ❌     | ✅          | ❌
-|                                          | A resource has been reported                                                          | ❌     | ❌          | ✅
-| User                                     | A user confirms the registration (if welcome notification is enabled)                 | ❌     | ✅          | ❌
-|                                          | A user earned a badge (if badges are enabled)                                         | ❌     | ✅          | ❌
-|                                          | A user has reached a new badge level (if badges are enabled)                          | ❌     | ✅          | ❌
-|                                          | A user has been officialized                                                          | ❌     | ❌          | ✅
-|                                          | A user asked their data export                                                          | ❌     | ✅          | ❌
-|                                          | A user I follow endorsed a resource                                                 | ✅     | ❌          | ❌
-|                                          | A public profile has been updated                                                     | ✅     | ❌          | ❌
-| User groups (if user groups are enabled) | A new user group has been created                                                     | ❌     | ❌          | ✅
-|                                          | A user group has updated its profile                                    | ❌     | ❌          | ✅
-|                                          | A user has been invited to join a user group                                          | ❌     | ✅          | ❌
-|                                          | A user has been promoted as group admin                                               | ❌     | ✅          | ❌
-|                                          | A user requested to join the user group                                               | ❌     | ✅          | ❌
-|                                          | A user request has been accepted to join the user group                               | ❌     | ✅          | ❌
-|                                          | A user request to join the user group has been rejected                               | ❌     | ✅          | ❌
-|                                          | The group admin has been demoted                                                      | ❌     | ✅          | ❌
-|                                          | The user has been removed from the group                                              | ❌     | ✅          | ❌
-| Assemblies                               | An admin of the assembly has added you as one of its members                          | ❌     | ✅          | ❌
-|                                          | You have been assigned a role for the assembly                                        | ❌     | ✅          | ❌
-| Processes                                | You have been assigned a role for the participatory process                           | ❌     | ✅          | ❌
-|                                          | The phases dates have been updated                                                    | ✅     | ❌          | ❌
-|                                          | A new phase has been activated                                                        | ✅     | ❌          | ❌
-| Conferences                              | You have been assigned a role for the conference                                      | ❌     | ✅          | ❌
-|                                          | The registration to the conference has been confirmed                                 | ❌     | ✅          | ❌
-|                                          | The registration for the conference is open                                           | ✅     | ❌          | ❌
-|                                          | The conference occupied slots are over X%                                             | ❌     | ❌          | ✅
-|                                          | The conference is taking place in 2 days                                              | ✅     | ❌          | ❌
-|                                          | The conference has been updated                                                       | ✅     | ❌          | ❌
-| Elections                                | The election is now active for the participatory space                                | ✅     | ❌          | ❌
-|                                          | You are added as a trustee for the election                                           | ❌     | ✅          | ❌
-|                                          | An admin has added you as trustee                                                     | ❌     | ✅          | ❌
-|                                          | Your vote was accepted                                                                | ❌     | ✅          | ❌
-|                                          | You have been assigned a role of the Polling Station                                  | ❌     | ✅          | ❌
-|                                          | Here is your Access Code                                                              | ❌     | ✅          | ❌
-| Initiatives                              | A user I follow created an initiative                                                 | ✅     | ❌          | ❌
-|                                          | My initiative has been created                                                        | ❌     | ✅          | ❌
-|                                          | A user I follow endorsed an initiative                                                | ✅     | ❌          | ❌
-|                                          | A user sent their initiative to technical validation                                    | ❌     | ❌          | ✅
-|                                          | The initiative has changed its status                                                 | ✅     | ✅          | ❌
-|                                          | The signatures end date for the initiative have been extended                         | ✅     | ❌          | ❌
-|                                          | The request to be part of the promoter committee for the initiative has been accepted | ❌     | ✅          | ❌
-|                                          | The request to be part of the promoter committee for the initiative has been rejected | ❌     | ✅          | ❌
-|                                          | A user wants to join your initiative                                                  | ❌     | ✅          | ❌
-|                                          | The initiative has reached the signatures threshold                                   | ❌     | ❌          | ✅
-|                                          | Your initiative has achieved the X% of signatures                                     | ✅     | ❌          | ❌
-|                                          | The initiative has achieved the X% of signatures                                      | ❌     | ✅          | ❌
-| Accountability                           | The proposal has been included in a result                                            | ✅     | ❌          | ❌
-|                                          | The result progress has been updated                                                  | ✅     | ❌          | ❌
-| Blogs                                    | A post has been published                                                             | ✅     | ❌          | ❌
-| Budgets                                  | The budget is now active                                                              | ✅     | ❌          | ❌
-| Comments                                 | A resource has a comment                                                      | ✅     | ❌          | ❌
-|                                          | A user group has left a comment on a resource                                        | ✅     | ❌          | ❌
-|                                          | A user has left a comment on a resource                                              | ✅     | ❌          | ❌
-|                                          | A user has replied your comment                                                       | ❌     | ✅          | ❌
-|                                          | A group you belong to has been mentioned                                              | ❌     | ✅          | ❌
-|                                          | You have been mentioned                                                               | ❌     | ✅          | ❌
-|                                          | Your comment in has been upvoted                                                      | ❌     | ✅          | ❌
-|                                          | Your comment in has been downvoted                                                    | ❌     | ✅          | ❌
-| Debates                                  | A debate has been created                                                             | ✅     | ❌          | ❌
-|                                          | Debate creation is enabled for participants                                           | ✅     | ❌          | ❌
-|                                          | Debate creation is no longer active                                                   | ✅     | ❌          | ❌
-|                                          | The debate was closed                                                                 | ✅     | ✅          | ❌
-| Meetings                                 | A meeting has been created                                                            | ✅     | ❌          | ❌
-|                                          | A meeting was closed                                                                  | ✅     | ✅          | ❌
-|                                          | A meeting was updated                                                                 | ✅     | ❌          | ❌
-|                                          | Your meeting's registration has been confirmed                                        | ❌     | ✅          | ❌
-|                                          | The allocated slots for the meeting are over X%                                       | ❌     | ❌          | ✅
-|                                          | The meeting has enabled registrations                                                 | ✅     | ❌          | ❌
-|                                          | The registration code for the meeting has been validated.                             | ❌     | ✅          | ❌
-|                                          | The meeting will start in less than 48h                                               | ✅     | ❌          | ❌
-| Proposals                                | A new proposal has been published                                                     | ✅     | ❌          | ❌
-|                                          | Proposal creation is open                                                             | ✅     | ❌          | ❌
-|                                          | Proposal supports are open                                                            | ✅     | ❌          | ❌
-|                                          | Proposal endorsements are open                                                        | ✅     | ❌          | ❌
-|                                          | Someone has left a note on the proposal                                               | ❌     | ❌          | ✅
-|                                          | A proposal is currently being evaluated                                               | ✅     | ✅          | ❌
-|                                          | A proposal has been rejected                                                          | ✅     | ✅          | ❌
-|                                          | A proposal has been accepted                                                          | ✅     | ✅          | ❌
-|                                          | An admin has updated the scope of your proposal                                       | ❌     | ✅          | ❌
-|                                          | An admin has updated the category of your proposal                                    | ❌     | ✅          | ❌
-|                                          | A proposal has been mentioned                                                         | ❌     | ✅          | ❌
-| Proposal drafts                          | A user requested access as a contributor                                              | ❌     | ✅          | ❌
-|                                          | You have been accepted to access as a contributor                                     | ❌     | ✅          | ❌
-|                                          | You have been rejected to access as a contributor                                     | ❌     | ✅          | ❌
-|                                          | A user has been rejected to access as a contributor                                   | ❌     | ✅          | ❌
-|                                          | A user has been accepted to access as a contributor                                   | ❌     | ✅          | ❌
-|                                          | A user withdrawn the collaborative draft                                              | ❌     | ✅          | ❌
-| Amendments (if amendments are enabled)   | An amendment has been rejected                                                        | ✅     | ✅          | ❌
-|                                          | An amendment has been accepted                                                        | ✅     | ✅          | ❌
-|                                          | An amendment has been created                                                         | ✅     | ✅          | ❌
-|                                          | An amendment has been promoted                                                        | ✅     | ✅          | ❌
-| Sortitions                               | A sortition has been created                                                          | ✅     | ❌          | ❌
-| Surveys                                  | A survey has been opened                                                              | ✅     | ❌          | ❌
-|                                          | A survey has been closed                                                              | ✅     | ❌          | ❌
+| Component                                | Action                                                                                | Follower | Affected user   | Administrator
+| Admin                                    | A new attachment has been created                                                     | ✅       | ❌              | ❌
+|                                          | An admin requested an export                                                          | ❌       | ❌              | ✅
+|                                          | A component has been published in a participatory space                               | ✅       | ❌              | ❌
+| Verifications                            | A participant has tried to verify themself with the data of another participant       | ❌       | ❌              | ✅
+| Moderation                               | An administrator moderated a resource because it has been reported                    | ❌       | ✅              | ❌
+|                                          | A resource has been reported                                                          | ❌       | ❌              | ✅
+| User                                     | A user confirms the registration (if welcome notification is enabled)                 | ❌       | ✅              | ❌
+|                                          | A user earned a badge (if badges are enabled)                                         | ❌       | ✅              | ❌
+|                                          | A user has reached a new badge level (if badges are enabled)                          | ❌       | ✅              | ❌
+|                                          | A user has been officialized                                                          | ❌       | ❌              | ✅
+|                                          | A user asked their data export                                                        | ❌       | ✅              | ❌
+|                                          | A user I follow endorsed a resource                                                   | ✅       | ❌              | ❌
+|                                          | A public profile has been updated                                                     | ✅       | ❌              | ❌
+| User groups (if user groups are enabled) | A new user group has been created                                                     | ❌       | ❌              | ✅
+|                                          | A user group has updated its profile                                                  | ❌       | ❌              | ✅
+|                                          | A user has been invited to join a user group                                          | ❌       | ✅              | ❌
+|                                          | A user has been promoted as group admin                                               | ❌       | ✅              | ❌
+|                                          | A user requested to join the user group                                               | ❌       | ✅              | ❌
+|                                          | A user request has been accepted to join the user group                               | ❌       | ✅              | ❌
+|                                          | A user request to join the user group has been rejected                               | ❌       | ✅              | ❌
+|                                          | The group admin has been demoted                                                      | ❌       | ✅              | ❌
+|                                          | The user has been removed from the group                                              | ❌       | ✅              | ❌
+| Assemblies                               | An admin of the assembly has added you as one of its members                          | ❌       | ✅              | ❌
+|                                          | You have been assigned a role for the assembly                                        | ❌       | ✅              | ❌
+| Processes                                | You have been assigned a role for the participatory process                           | ❌       | ✅              | ❌
+|                                          | The phases dates have been updated                                                    | ✅       | ❌              | ❌
+|                                          | A new phase has been activated                                                        | ✅       | ❌              | ❌
+| Conferences                              | You have been assigned a role for the conference                                      | ❌       | ✅              | ❌
+|                                          | The registration to the conference has been confirmed                                 | ❌       | ✅              | ❌
+|                                          | The registration for the conference is open                                           | ✅       | ❌              | ❌
+|                                          | The conference occupied slots are over X%                                             | ❌       | ❌              | ✅
+|                                          | The conference is taking place in 2 days                                              | ✅       | ❌              | ❌
+|                                          | The conference has been updated                                                       | ✅       | ❌              | ❌
+| Elections                                | The election is now active for the participatory space                                | ✅       | ❌              | ❌
+|                                          | You are added as a trustee for the election                                           | ❌       | ✅              | ❌
+|                                          | An admin has added you as trustee                                                     | ❌       | ✅              | ❌
+|                                          | Your vote was accepted                                                                | ❌       | ✅              | ❌
+|                                          | You have been assigned a role of the Polling Station                                  | ❌       | ✅              | ❌
+|                                          | Here is your Access Code                                                              | ❌       | ✅              | ❌
+| Initiatives                              | A user I follow created an initiative                                                 | ✅       | ❌              | ❌
+|                                          | My initiative has been created                                                        | ❌       | ✅              | ❌
+|                                          | A user I follow endorsed an initiative                                                | ✅       | ❌              | ❌
+|                                          | A user sent their initiative to technical validation                                  | ❌       | ❌              | ✅
+|                                          | The initiative has changed its status                                                 | ✅       | ✅              | ❌
+|                                          | The signatures end date for the initiative have been extended                         | ✅       | ❌              | ❌
+|                                          | The request to be part of the promoter committee for the initiative has been accepted | ❌       | ✅              | ❌
+|                                          | The request to be part of the promoter committee for the initiative has been rejected | ❌       | ✅              | ❌
+|                                          | A user wants to join your initiative                                                  | ❌       | ✅              | ❌
+|                                          | The initiative has reached the signatures threshold                                   | ❌       | ❌              | ✅
+|                                          | Your initiative has achieved the X% of signatures                                     | ✅       | ❌              | ❌
+|                                          | The initiative has achieved the X% of signatures                                      | ❌       | ✅              | ❌
+| Accountability                           | The proposal has been included in a result                                            | ✅       | ❌              | ❌
+|                                          | The result progress has been updated                                                  | ✅       | ❌              | ❌
+| Blogs                                    | A post has been published                                                             | ✅       | ❌              | ❌
+| Budgets                                  | The budget is now active                                                              | ✅       | ❌              | ❌
+| Comments                                 | A resource has a comment                                                              | ✅       | ❌              | ❌
+|                                          | A user group has left a comment on a resource                                         | ✅       | ❌              | ❌
+|                                          | A user has left a comment on a resource                                               | ✅       | ❌              | ❌
+|                                          | A user has replied your comment                                                       | ❌       | ✅              | ❌
+|                                          | A group you belong to has been mentioned                                              | ❌       | ✅              | ❌
+|                                          | You have been mentioned                                                               | ❌       | ✅              | ❌
+|                                          | Your comment in has been upvoted                                                      | ❌       | ✅              | ❌
+|                                          | Your comment in has been downvoted                                                    | ❌       | ✅              | ❌
+| Debates                                  | A debate has been created                                                             | ✅       | ❌              | ❌
+|                                          | Debate creation is enabled for participants                                           | ✅       | ❌              | ❌
+|                                          | Debate creation is no longer active                                                   | ✅       | ❌              | ❌
+|                                          | The debate was closed                                                                 | ✅       | ✅              | ❌
+| Meetings                                 | A meeting has been created                                                            | ✅       | ❌              | ❌
+|                                          | A meeting was closed                                                                  | ✅       | ✅              | ❌
+|                                          | A meeting was updated                                                                 | ✅       | ❌              | ❌
+|                                          | Your meeting's registration has been confirmed                                        | ❌       | ✅              | ❌
+|                                          | The allocated slots for the meeting are over X%                                       | ❌       | ❌              | ✅
+|                                          | The meeting has enabled registrations                                                 | ✅       | ❌              | ❌
+|                                          | The registration code for the meeting has been validated.                             | ❌       | ✅              | ❌
+|                                          | The meeting will start in less than 48h                                               | ✅       | ❌              | ❌
+| Proposals                                | A new proposal has been published                                                     | ✅       | ❌              | ❌
+|                                          | Proposal creation is open                                                             | ✅       | ❌              | ❌
+|                                          | Proposal supports are open                                                            | ✅       | ❌              | ❌
+|                                          | Proposal endorsements are open                                                        | ✅       | ❌              | ❌
+|                                          | Someone has left a note on the proposal                                               | ❌       | ❌              | ✅
+|                                          | A proposal is currently being evaluated                                               | ✅       | ✅              | ❌
+|                                          | A proposal has been rejected                                                          | ✅       | ✅              | ❌
+|                                          | A proposal has been accepted                                                          | ✅       | ✅              | ❌
+|                                          | An admin has updated the scope of your proposal                                       | ❌       | ✅              | ❌
+|                                          | An admin has updated the category of your proposal                                    | ❌       | ✅              | ❌
+|                                          | A proposal has been mentioned                                                         | ❌       | ✅              | ❌
+| Proposal drafts                          | A user requested access as a contributor                                              | ❌       | ✅              | ❌
+|                                          | You have been accepted to access as a contributor                                     | ❌       | ✅              | ❌
+|                                          | You have been rejected to access as a contributor                                     | ❌       | ✅              | ❌
+|                                          | A user has been rejected to access as a contributor                                   | ❌       | ✅              | ❌
+|                                          | A user has been accepted to access as a contributor                                   | ❌       | ✅              | ❌
+|                                          | A user withdrawn the collaborative draft                                              | ❌       | ✅              | ❌
+| Amendments (if amendments are enabled)   | An amendment has been rejected                                                        | ✅       | ✅              | ❌
+|                                          | An amendment has been accepted                                                        | ✅       | ✅              | ❌
+|                                          | An amendment has been created                                                         | ✅       | ✅              | ❌
+|                                          | An amendment has been promoted                                                        | ✅       | ✅              | ❌
+| Sortitions                               | A sortition has been created                                                          | ✅       | ❌              | ❌
+| Surveys                                  | A survey has been opened                                                              | ✅       | ❌              | ❌
+|                                          | A survey has been closed                                                              | ✅       | ❌              | ❌
 |============================================================================================================================================================================

--- a/docs/en/modules/admin/pages/features/notifications.adoc
+++ b/docs/en/modules/admin/pages/features/notifications.adoc
@@ -38,15 +38,15 @@ Below is an exhaustive list of actions that trigger notifications to participant
 | A user asked their data export                                                        | User                                             | ❌       | ✅              | ❌
 | A user I follow endorsed a resource                                                   | User                                             | ✅       | ❌              | ❌
 | A public profile has been updated                                                     | User                                             | ✅       | ❌              | ❌
-| A new user group has been created                                                     | User groupsfootnote:[If user groups are enabled] | ❌       | ❌              | ✅
-| A user group has updated its profile                                                  | User groupsfootnote:[If user groups are enabled] | ❌       | ❌              | ✅
-| A user has been invited to join a user group                                          | User groupsfootnote:[If user groups are enabled] | ❌       | ✅              | ❌
-| A user has been promoted as group admin                                               | User groupsfootnote:[If user groups are enabled] | ❌       | ✅              | ❌
-| A user requested to join the user group                                               | User groupsfootnote:[If user groups are enabled] | ❌       | ✅              | ❌
-| A user request has been accepted to join the user group                               | User groupsfootnote:[If user groups are enabled] | ❌       | ✅              | ❌
-| A user request to join the user group has been rejected                               | User groupsfootnote:[If user groups are enabled] | ❌       | ✅              | ❌
-| The group admin has been demoted                                                      | User groupsfootnote:[If user groups are enabled] | ❌       | ✅              | ❌
-| The user has been removed from the group                                              | User groupsfootnote:[If user groups are enabled] | ❌       | ✅              | ❌
+| A new user group has been created                                                     | User groupsfootnote:user-group[If user groups are enabled] | ❌       | ❌              | ✅
+| A user group has updated its profile                                                  | User groupsfootnote:user-group[] | ❌       | ❌              | ✅
+| A user has been invited to join a user group                                          | User groupsfootnote:user-group[] | ❌       | ✅              | ❌
+| A user has been promoted as group admin                                               | User groupsfootnote:user-group[] | ❌       | ✅              | ❌
+| A user requested to join the user group                                               | User groupsfootnote:user-group[] | ❌       | ✅              | ❌
+| A user request has been accepted to join the user group                               | User groupsfootnote:user-group[] | ❌       | ✅              | ❌
+| A user request to join the user group has been rejected                               | User groupsfootnote:user-group[] | ❌       | ✅              | ❌
+| The group admin has been demoted                                                      | User groupsfootnote:user-group[] | ❌       | ✅              | ❌
+| The user has been removed from the group                                              | User groupsfootnote:user-group[] | ❌       | ✅              | ❌
 | An admin of the assembly has added you as one of its members                          | Assemblies                                       | ❌       | ✅              | ❌
 | You have been assigned a role for the assembly                                        | Assemblies                                       | ❌       | ✅              | ❌
 | You have been assigned a role for the participatory process                           | Processes                                        | ❌       | ✅              | ❌
@@ -117,10 +117,10 @@ Below is an exhaustive list of actions that trigger notifications to participant
 | A user has been rejected to access as a contributor                                   | Proposal drafts                                  | ❌       | ✅              | ❌
 | A user has been accepted to access as a contributor                                   | Proposal drafts                                  | ❌       | ✅              | ❌
 | A user withdrawn the collaborative draft                                              | Proposal drafts                                  | ❌       | ✅              | ❌
-| An amendment has been rejected                                                        | Amendmentsfootnote:[If amendments are enabled]   | ✅       | ✅              | ❌
-| An amendment has been accepted                                                        | Amendmentsfootnote:[If amendments are enabled]   | ✅       | ✅              | ❌
-| An amendment has been created                                                         | Amendmentsfootnote:[If amendments are enabled]   | ✅       | ✅              | ❌
-| An amendment has been promoted                                                        | Amendmentsfootnote:[If amendments are enabled]   | ✅       | ✅              | ❌
+| An amendment has been rejected                                                        | Amendmentsfootnote:amendments[If amendments are enabled]   | ✅       | ✅              | ❌
+| An amendment has been accepted                                                        | Amendmentsfootnote:amendments[]   | ✅       | ✅              | ❌
+| An amendment has been created                                                         | Amendmentsfootnote:amendments[]   | ✅       | ✅              | ❌
+| An amendment has been promoted                                                        | Amendmentsfootnote:amendments[]   | ✅       | ✅              | ❌
 | A sortition has been created                                                          | Sortitions                                       | ✅       | ❌              | ❌
 | A survey has been opened                                                              | Surveys                                          | ✅       | ❌              | ❌
 | A survey has been closed                                                              | Surveys                                          | ✅       | ❌              | ❌

--- a/docs/en/modules/admin/pages/features/notifications.adoc
+++ b/docs/en/modules/admin/pages/features/notifications.adoc
@@ -23,105 +23,105 @@ Below is an exhaustive list of actions that trigger notifications to participant
 
 [options="header"]
 |============================================================================================================================================================================
-| Component                                | Action                                                                                | Follower | Affected user   | Administrator
+| Action                                                                                | Component                                | Follower | Affected user   | Administrator
 
-| Admin                                    | A new attachment has been created                                                     | ✅       | ❌              | ❌
-|                                          | An admin requested an export                                                          | ❌       | ❌              | ✅
-|                                          | A component has been published in a participatory space                               | ✅       | ❌              | ❌
-| Verifications                            | A participant has tried to verify themself with the data of another participant       | ❌       | ❌              | ✅
-| Moderation                               | An administrator moderated a resource because it has been reported                    | ❌       | ✅              | ❌
-|                                          | A resource has been reported                                                          | ❌       | ❌              | ✅
-| User                                     | A user confirms the registration (if welcome notification is enabled)                 | ❌       | ✅              | ❌
-|                                          | A user earned a badge (if badges are enabled)                                         | ❌       | ✅              | ❌
-|                                          | A user has reached a new badge level (if badges are enabled)                          | ❌       | ✅              | ❌
-|                                          | A user has been officialized                                                          | ❌       | ❌              | ✅
-|                                          | A user asked their data export                                                        | ❌       | ✅              | ❌
-|                                          | A user I follow endorsed a resource                                                   | ✅       | ❌              | ❌
-|                                          | A public profile has been updated                                                     | ✅       | ❌              | ❌
-| User groups (if user groups are enabled) | A new user group has been created                                                     | ❌       | ❌              | ✅
-|                                          | A user group has updated its profile                                                  | ❌       | ❌              | ✅
-|                                          | A user has been invited to join a user group                                          | ❌       | ✅              | ❌
-|                                          | A user has been promoted as group admin                                               | ❌       | ✅              | ❌
-|                                          | A user requested to join the user group                                               | ❌       | ✅              | ❌
-|                                          | A user request has been accepted to join the user group                               | ❌       | ✅              | ❌
-|                                          | A user request to join the user group has been rejected                               | ❌       | ✅              | ❌
-|                                          | The group admin has been demoted                                                      | ❌       | ✅              | ❌
-|                                          | The user has been removed from the group                                              | ❌       | ✅              | ❌
-| Assemblies                               | An admin of the assembly has added you as one of its members                          | ❌       | ✅              | ❌
-|                                          | You have been assigned a role for the assembly                                        | ❌       | ✅              | ❌
-| Processes                                | You have been assigned a role for the participatory process                           | ❌       | ✅              | ❌
-|                                          | The phases dates have been updated                                                    | ✅       | ❌              | ❌
-|                                          | A new phase has been activated                                                        | ✅       | ❌              | ❌
-| Conferences                              | You have been assigned a role for the conference                                      | ❌       | ✅              | ❌
-|                                          | The registration to the conference has been confirmed                                 | ❌       | ✅              | ❌
-|                                          | The registration for the conference is open                                           | ✅       | ❌              | ❌
-|                                          | The conference occupied slots are over X%                                             | ❌       | ❌              | ✅
-|                                          | The conference is taking place in 2 days                                              | ✅       | ❌              | ❌
-|                                          | The conference has been updated                                                       | ✅       | ❌              | ❌
-| Elections                                | The election is now active for the participatory space                                | ✅       | ❌              | ❌
-|                                          | You are added as a trustee for the election                                           | ❌       | ✅              | ❌
-|                                          | An admin has added you as trustee                                                     | ❌       | ✅              | ❌
-|                                          | Your vote was accepted                                                                | ❌       | ✅              | ❌
-|                                          | You have been assigned a role of the Polling Station                                  | ❌       | ✅              | ❌
-|                                          | Here is your Access Code                                                              | ❌       | ✅              | ❌
-| Initiatives                              | A user I follow created an initiative                                                 | ✅       | ❌              | ❌
-|                                          | My initiative has been created                                                        | ❌       | ✅              | ❌
-|                                          | A user I follow endorsed an initiative                                                | ✅       | ❌              | ❌
-|                                          | A user sent their initiative to technical validation                                  | ❌       | ❌              | ✅
-|                                          | The initiative has changed its status                                                 | ✅       | ✅              | ❌
-|                                          | The signatures end date for the initiative have been extended                         | ✅       | ❌              | ❌
-|                                          | The request to be part of the promoter committee for the initiative has been accepted | ❌       | ✅              | ❌
-|                                          | The request to be part of the promoter committee for the initiative has been rejected | ❌       | ✅              | ❌
-|                                          | A user wants to join your initiative                                                  | ❌       | ✅              | ❌
-|                                          | The initiative has reached the signatures threshold                                   | ❌       | ❌              | ✅
-|                                          | Your initiative has achieved the X% of signatures                                     | ✅       | ❌              | ❌
-|                                          | The initiative has achieved the X% of signatures                                      | ❌       | ✅              | ❌
-| Accountability                           | The proposal has been included in a result                                            | ✅       | ❌              | ❌
-|                                          | The result progress has been updated                                                  | ✅       | ❌              | ❌
-| Blogs                                    | A post has been published                                                             | ✅       | ❌              | ❌
-| Budgets                                  | The budget is now active                                                              | ✅       | ❌              | ❌
-| Comments                                 | A resource has a comment                                                              | ✅       | ❌              | ❌
-|                                          | A user group has left a comment on a resource                                         | ✅       | ❌              | ❌
-|                                          | A user has left a comment on a resource                                               | ✅       | ❌              | ❌
-|                                          | A user has replied your comment                                                       | ❌       | ✅              | ❌
-|                                          | A group you belong to has been mentioned                                              | ❌       | ✅              | ❌
-|                                          | You have been mentioned                                                               | ❌       | ✅              | ❌
-|                                          | Your comment in has been upvoted                                                      | ❌       | ✅              | ❌
-|                                          | Your comment in has been downvoted                                                    | ❌       | ✅              | ❌
-| Debates                                  | A debate has been created                                                             | ✅       | ❌              | ❌
-|                                          | Debate creation is enabled for participants                                           | ✅       | ❌              | ❌
-|                                          | Debate creation is no longer active                                                   | ✅       | ❌              | ❌
-|                                          | The debate was closed                                                                 | ✅       | ✅              | ❌
-| Meetings                                 | A meeting has been created                                                            | ✅       | ❌              | ❌
-|                                          | A meeting was closed                                                                  | ✅       | ✅              | ❌
-|                                          | A meeting was updated                                                                 | ✅       | ❌              | ❌
-|                                          | Your meeting's registration has been confirmed                                        | ❌       | ✅              | ❌
-|                                          | The allocated slots for the meeting are over X%                                       | ❌       | ❌              | ✅
-|                                          | The meeting has enabled registrations                                                 | ✅       | ❌              | ❌
-|                                          | The registration code for the meeting has been validated.                             | ❌       | ✅              | ❌
-|                                          | The meeting will start in less than 48h                                               | ✅       | ❌              | ❌
-| Proposals                                | A new proposal has been published                                                     | ✅       | ❌              | ❌
-|                                          | Proposal creation is open                                                             | ✅       | ❌              | ❌
-|                                          | Proposal supports are open                                                            | ✅       | ❌              | ❌
-|                                          | Proposal endorsements are open                                                        | ✅       | ❌              | ❌
-|                                          | Someone has left a note on the proposal                                               | ❌       | ❌              | ✅
-|                                          | A proposal is currently being evaluated                                               | ✅       | ✅              | ❌
-|                                          | A proposal has been rejected                                                          | ✅       | ✅              | ❌
-|                                          | A proposal has been accepted                                                          | ✅       | ✅              | ❌
-|                                          | An admin has updated the scope of your proposal                                       | ❌       | ✅              | ❌
-|                                          | An admin has updated the category of your proposal                                    | ❌       | ✅              | ❌
-|                                          | A proposal has been mentioned                                                         | ❌       | ✅              | ❌
-| Proposal drafts                          | A user requested access as a contributor                                              | ❌       | ✅              | ❌
-|                                          | You have been accepted to access as a contributor                                     | ❌       | ✅              | ❌
-|                                          | You have been rejected to access as a contributor                                     | ❌       | ✅              | ❌
-|                                          | A user has been rejected to access as a contributor                                   | ❌       | ✅              | ❌
-|                                          | A user has been accepted to access as a contributor                                   | ❌       | ✅              | ❌
-|                                          | A user withdrawn the collaborative draft                                              | ❌       | ✅              | ❌
-| Amendments (if amendments are enabled)   | An amendment has been rejected                                                        | ✅       | ✅              | ❌
-|                                          | An amendment has been accepted                                                        | ✅       | ✅              | ❌
-|                                          | An amendment has been created                                                         | ✅       | ✅              | ❌
-|                                          | An amendment has been promoted                                                        | ✅       | ✅              | ❌
-| Sortitions                               | A sortition has been created                                                          | ✅       | ❌              | ❌
-| Surveys                                  | A survey has been opened                                                              | ✅       | ❌              | ❌
-|                                          | A survey has been closed                                                              | ✅       | ❌              | ❌
+| A new attachment has been created                                                     | Admin                                    | ✅       | ❌              | ❌
+| An admin requested an export                                                          |                                          | ❌       | ❌              | ✅
+| A component has been published in a participatory space                               |                                          | ✅       | ❌              | ❌
+| A participant has tried to verify themself with the data of another participant       | Verifications                            | ❌       | ❌              | ✅
+| An administrator moderated a resource because it has been reported                    | Moderation                               | ❌       | ✅              | ❌
+| A resource has been reported                                                          |                                          | ❌       | ❌              | ✅
+| A user confirms the registration (if welcome notification is enabled)                 | User                                     | ❌       | ✅              | ❌
+| A user earned a badge (if badges are enabled)                                         |                                          | ❌       | ✅              | ❌
+| A user has reached a new badge level (if badges are enabled)                          |                                          | ❌       | ✅              | ❌
+| A user has been officialized                                                          |                                          | ❌       | ❌              | ✅
+| A user asked their data export                                                        |                                          | ❌       | ✅              | ❌
+| A user I follow endorsed a resource                                                   |                                          | ✅       | ❌              | ❌
+| A public profile has been updated                                                     |                                          | ✅       | ❌              | ❌
+| A new user group has been created                                                     | User groups (if user groups are enabled) | ❌       | ❌              | ✅
+| A user group has updated its profile                                                  |                                          | ❌       | ❌              | ✅
+| A user has been invited to join a user group                                          |                                          | ❌       | ✅              | ❌
+| A user has been promoted as group admin                                               |                                          | ❌       | ✅              | ❌
+| A user requested to join the user group                                               |                                          | ❌       | ✅              | ❌
+| A user request has been accepted to join the user group                               |                                          | ❌       | ✅              | ❌
+| A user request to join the user group has been rejected                               |                                          | ❌       | ✅              | ❌
+| The group admin has been demoted                                                      |                                          | ❌       | ✅              | ❌
+| The user has been removed from the group                                              |                                          | ❌       | ✅              | ❌
+| An admin of the assembly has added you as one of its members                          | Assemblies                               | ❌       | ✅              | ❌
+| You have been assigned a role for the assembly                                        |                                          | ❌       | ✅              | ❌
+| You have been assigned a role for the participatory process                           | Processes                                | ❌       | ✅              | ❌
+| The phases dates have been updated                                                    |                                          | ✅       | ❌              | ❌
+| A new phase has been activated                                                        |                                          | ✅       | ❌              | ❌
+| You have been assigned a role for the conference                                      | Conferences                              | ❌       | ✅              | ❌
+| The registration to the conference has been confirmed                                 |                                          | ❌       | ✅              | ❌
+| The registration for the conference is open                                           |                                          | ✅       | ❌              | ❌
+| The conference occupied slots are over X%                                             |                                          | ❌       | ❌              | ✅
+| The conference is taking place in 2 days                                              |                                          | ✅       | ❌              | ❌
+| The conference has been updated                                                       |                                          | ✅       | ❌              | ❌
+| The election is now active for the participatory space                                | Elections                                | ✅       | ❌              | ❌
+| You are added as a trustee for the election                                           |                                          | ❌       | ✅              | ❌
+| An admin has added you as trustee                                                     |                                          | ❌       | ✅              | ❌
+| Your vote was accepted                                                                |                                          | ❌       | ✅              | ❌
+| You have been assigned a role of the Polling Station                                  |                                          | ❌       | ✅              | ❌
+| Here is your Access Code                                                              |                                          | ❌       | ✅              | ❌
+| A user I follow created an initiative                                                 | Initiatives                              | ✅       | ❌              | ❌
+| My initiative has been created                                                        |                                          | ❌       | ✅              | ❌
+| A user I follow endorsed an initiative                                                |                                          | ✅       | ❌              | ❌
+| A user sent their initiative to technical validation                                  |                                          | ❌       | ❌              | ✅
+| The initiative has changed its status                                                 |                                          | ✅       | ✅              | ❌
+| The signatures end date for the initiative have been extended                         |                                          | ✅       | ❌              | ❌
+| The request to be part of the promoter committee for the initiative has been accepted |                                          | ❌       | ✅              | ❌
+| The request to be part of the promoter committee for the initiative has been rejected |                                          | ❌       | ✅              | ❌
+| A user wants to join your initiative                                                  |                                          | ❌       | ✅              | ❌
+| The initiative has reached the signatures threshold                                   |                                          | ❌       | ❌              | ✅
+| Your initiative has achieved the X% of signatures                                     |                                          | ✅       | ❌              | ❌
+| The initiative has achieved the X% of signatures                                      |                                          | ❌       | ✅              | ❌
+| The proposal has been included in a result                                            | Accountability                           | ✅       | ❌              | ❌
+| The result progress has been updated                                                  |                                          | ✅       | ❌              | ❌
+| A post has been published                                                             | Blogs                                    | ✅       | ❌              | ❌
+| The budget is now active                                                              | Budgets                                  | ✅       | ❌              | ❌
+| A resource has a comment                                                              | Comments                                 | ✅       | ❌              | ❌
+| A user group has left a comment on a resource                                         |                                          | ✅       | ❌              | ❌
+| A user has left a comment on a resource                                               |                                          | ✅       | ❌              | ❌
+| A user has replied your comment                                                       |                                          | ❌       | ✅              | ❌
+| A group you belong to has been mentioned                                              |                                          | ❌       | ✅              | ❌
+| You have been mentioned                                                               |                                          | ❌       | ✅              | ❌
+| Your comment in has been upvoted                                                      |                                          | ❌       | ✅              | ❌
+| Your comment in has been downvoted                                                    |                                          | ❌       | ✅              | ❌
+| A debate has been created                                                             | Debates                                  | ✅       | ❌              | ❌
+| Debate creation is enabled for participants                                           |                                          | ✅       | ❌              | ❌
+| Debate creation is no longer active                                                   |                                          | ✅       | ❌              | ❌
+| The debate was closed                                                                 |                                          | ✅       | ✅              | ❌
+| A meeting has been created                                                            | Meetings                                 | ✅       | ❌              | ❌
+| A meeting was closed                                                                  |                                          | ✅       | ✅              | ❌
+| A meeting was updated                                                                 |                                          | ✅       | ❌              | ❌
+| Your meeting's registration has been confirmed                                        |                                          | ❌       | ✅              | ❌
+| The allocated slots for the meeting are over X%                                       |                                          | ❌       | ❌              | ✅
+| The meeting has enabled registrations                                                 |                                          | ✅       | ❌              | ❌
+| The registration code for the meeting has been validated.                             |                                          | ❌       | ✅              | ❌
+| The meeting will start in less than 48h                                               |                                          | ✅       | ❌              | ❌
+| A new proposal has been published                                                     | Proposals                                | ✅       | ❌              | ❌
+| Proposal creation is open                                                             |                                          | ✅       | ❌              | ❌
+| Proposal supports are open                                                            |                                          | ✅       | ❌              | ❌
+| Proposal endorsements are open                                                        |                                          | ✅       | ❌              | ❌
+| Someone has left a note on the proposal                                               |                                          | ❌       | ❌              | ✅
+| A proposal is currently being evaluated                                               |                                          | ✅       | ✅              | ❌
+| A proposal has been rejected                                                          |                                          | ✅       | ✅              | ❌
+| A proposal has been accepted                                                          |                                          | ✅       | ✅              | ❌
+| An admin has updated the scope of your proposal                                       |                                          | ❌       | ✅              | ❌
+| An admin has updated the category of your proposal                                    |                                          | ❌       | ✅              | ❌
+| A proposal has been mentioned                                                         |                                          | ❌       | ✅              | ❌
+| A user requested access as a contributor                                              | Proposal drafts                          | ❌       | ✅              | ❌
+| You have been accepted to access as a contributor                                     |                                          | ❌       | ✅              | ❌
+| You have been rejected to access as a contributor                                     |                                          | ❌       | ✅              | ❌
+| A user has been rejected to access as a contributor                                   |                                          | ❌       | ✅              | ❌
+| A user has been accepted to access as a contributor                                   |                                          | ❌       | ✅              | ❌
+| A user withdrawn the collaborative draft                                              |                                          | ❌       | ✅              | ❌
+| An amendment has been rejected                                                        | Amendments (if amendments are enabled)   | ✅       | ✅              | ❌
+| An amendment has been accepted                                                        |                                          | ✅       | ✅              | ❌
+| An amendment has been created                                                         |                                          | ✅       | ✅              | ❌
+| An amendment has been promoted                                                        |                                          | ✅       | ✅              | ❌
+| A sortition has been created                                                          | Sortitions                               | ✅       | ❌              | ❌
+| A survey has been opened                                                              | Surveys                                  | ✅       | ❌              | ❌
+| A survey has been closed                                                              |                                          | ✅       | ❌              | ❌
 |============================================================================================================================================================================

--- a/docs/en/modules/admin/pages/features/notifications.adoc
+++ b/docs/en/modules/admin/pages/features/notifications.adoc
@@ -38,15 +38,15 @@ Below is an exhaustive list of actions that trigger notifications to participant
 | A user asked their data export                                                        | User                                     | ❌       | ✅              | ❌
 | A user I follow endorsed a resource                                                   | User                                     | ✅       | ❌              | ❌
 | A public profile has been updated                                                     | User                                     | ✅       | ❌              | ❌
-| A new user group has been created                                                     | User groups (if user groups are enabled) | ❌       | ❌              | ✅
-| A user group has updated its profile                                                  | User groups (if user groups are enabled) | ❌       | ❌              | ✅
-| A user has been invited to join a user group                                          | User groups (if user groups are enabled) | ❌       | ✅              | ❌
-| A user has been promoted as group admin                                               | User groups (if user groups are enabled) | ❌       | ✅              | ❌
-| A user requested to join the user group                                               | User groups (if user groups are enabled) | ❌       | ✅              | ❌
-| A user request has been accepted to join the user group                               | User groups (if user groups are enabled) | ❌       | ✅              | ❌
-| A user request to join the user group has been rejected                               | User groups (if user groups are enabled) | ❌       | ✅              | ❌
-| The group admin has been demoted                                                      | User groups (if user groups are enabled) | ❌       | ✅              | ❌
-| The user has been removed from the group                                              | User groups (if user groups are enabled) | ❌       | ✅              | ❌
+| A new user group has been created                                                     | User groupsfootnote:[If user groups are enabled] | ❌       | ❌              | ✅
+| A user group has updated its profile                                                  | User groupsfootnote:[If user groups are enabled] | ❌       | ❌              | ✅
+| A user has been invited to join a user group                                          | User groupsfootnote:[If user groups are enabled] | ❌       | ✅              | ❌
+| A user has been promoted as group admin                                               | User groupsfootnote:[If user groups are enabled] | ❌       | ✅              | ❌
+| A user requested to join the user group                                               | User groupsfootnote:[If user groups are enabled] | ❌       | ✅              | ❌
+| A user request has been accepted to join the user group                               | User groupsfootnote:[If user groups are enabled] | ❌       | ✅              | ❌
+| A user request to join the user group has been rejected                               | User groupsfootnote:[If user groups are enabled] | ❌       | ✅              | ❌
+| The group admin has been demoted                                                      | User groupsfootnote:[If user groups are enabled] | ❌       | ✅              | ❌
+| The user has been removed from the group                                              | User groupsfootnote:[If user groups are enabled] | ❌       | ✅              | ❌
 | An admin of the assembly has added you as one of its members                          | Assemblies                               | ❌       | ✅              | ❌
 | You have been assigned a role for the assembly                                        | Assemblies                               | ❌       | ✅              | ❌
 | You have been assigned a role for the participatory process                           | Processes                                | ❌       | ✅              | ❌
@@ -117,10 +117,10 @@ Below is an exhaustive list of actions that trigger notifications to participant
 | A user has been rejected to access as a contributor                                   | Proposal drafts                          | ❌       | ✅              | ❌
 | A user has been accepted to access as a contributor                                   | Proposal drafts                          | ❌       | ✅              | ❌
 | A user withdrawn the collaborative draft                                              | Proposal drafts                          | ❌       | ✅              | ❌
-| An amendment has been rejected                                                        | Amendments (if amendments are enabled)   | ✅       | ✅              | ❌
-| An amendment has been accepted                                                        | Amendments (if amendments are enabled)   | ✅       | ✅              | ❌
-| An amendment has been created                                                         | Amendments (if amendments are enabled)   | ✅       | ✅              | ❌
-| An amendment has been promoted                                                        | Amendments (if amendments are enabled)   | ✅       | ✅              | ❌
+| An amendment has been rejected                                                        | Amendmentsfootnote:[If amendments are enabled] | ✅       | ✅              | ❌
+| An amendment has been accepted                                                        | Amendmentsfootnote:[If amendments are enabled] | ✅       | ✅              | ❌
+| An amendment has been created                                                         | Amendmentsfootnote:[If amendments are enabled] | ✅       | ✅              | ❌
+| An amendment has been promoted                                                        | Amendmentsfootnote:[If amendments are enabled] | ✅       | ✅              | ❌
 | A sortition has been created                                                          | Sortitions                               | ✅       | ❌              | ❌
 | A survey has been opened                                                              | Surveys                                  | ✅       | ❌              | ❌
 | A survey has been closed                                                              | Surveys                                  | ✅       | ❌              | ❌

--- a/docs/en/modules/admin/pages/features/notifications.adoc
+++ b/docs/en/modules/admin/pages/features/notifications.adoc
@@ -23,8 +23,8 @@ Below is an exhaustive list of actions that trigger notifications to participant
 
 [options="header"]
 |============================================================================================================================================================================
-| 0.28 version                             |                                                                                       | Roles    |               |
 | Component                                | Action                                                                                | Follower | Affected user   | Administrator
+
 | Admin                                    | A new attachment has been created                                                     | ✅       | ❌              | ❌
 |                                          | An admin requested an export                                                          | ❌       | ❌              | ✅
 |                                          | A component has been published in a participatory space                               | ✅       | ❌              | ❌

--- a/docs/en/modules/admin/pages/features/notifications.adoc
+++ b/docs/en/modules/admin/pages/features/notifications.adoc
@@ -21,7 +21,7 @@ image:features/notifications/no_notifications_yet.png[Example of notifications p
 
 Below is an exhaustive list of actions that trigger notifications to participants. Participants are divided into three categories: assigned users, followers and administrators.
 
-[options="header"]
+[cols="7,2,1,1,1"]
 |============================================================================================================================================================================
 | Action                                                                                | Feature                                  | Follower | Affected user   | Administrator
 

--- a/docs/en/modules/admin/pages/features/notifications.adoc
+++ b/docs/en/modules/admin/pages/features/notifications.adoc
@@ -23,7 +23,7 @@ Below is an exhaustive list of actions that trigger notifications to participant
 
 [options="header"]
 |============================================================================================================================================================================
-| Action                                                                                | Component                                | Follower | Affected user   | Administrator
+| Action                                                                                | Feature                                  | Follower | Affected user   | Administrator
 
 | A new attachment has been created                                                     | Admin                                    | ✅       | ❌              | ❌
 | An admin requested an export                                                          | Admin                                    | ❌       | ❌              | ✅

--- a/docs/en/modules/admin/pages/features/notifications.adoc
+++ b/docs/en/modules/admin/pages/features/notifications.adoc
@@ -23,21 +23,21 @@ Below is an exhaustive list of actions that trigger notifications to participant
 
 [cols="7,2,1,1,1"]
 |============================================================================================================================================================================
-| Action                                                                                | Feature                                  | Follower | Affected user   | Administrator
+| Action                                                                                | Feature                                          | Follower | Affected user   | Administrator
 
-| A new attachment has been created                                                     | Admin                                    | ✅       | ❌              | ❌
-| An admin requested an export                                                          | Admin                                    | ❌       | ❌              | ✅
-| A component has been published in a participatory space                               | Admin                                    | ✅       | ❌              | ❌
-| A participant has tried to verify themself with the data of another participant       | Verifications                            | ❌       | ❌              | ✅
-| An administrator moderated a resource because it has been reported                    | Moderation                               | ❌       | ✅              | ❌
-| A resource has been reported                                                          | Moderation                               | ❌       | ❌              | ✅
-| A user confirms the registration (if welcome notification is enabled)                 | User                                     | ❌       | ✅              | ❌
-| A user earned a badge (if badges are enabled)                                         | User                                     | ❌       | ✅              | ❌
-| A user has reached a new badge level (if badges are enabled)                          | User                                     | ❌       | ✅              | ❌
-| A user has been officialized                                                          | User                                     | ❌       | ❌              | ✅
-| A user asked their data export                                                        | User                                     | ❌       | ✅              | ❌
-| A user I follow endorsed a resource                                                   | User                                     | ✅       | ❌              | ❌
-| A public profile has been updated                                                     | User                                     | ✅       | ❌              | ❌
+| A new attachment has been created                                                     | Admin                                            | ✅       | ❌              | ❌
+| An admin requested an export                                                          | Admin                                            | ❌       | ❌              | ✅
+| A component has been published in a participatory space                               | Admin                                            | ✅       | ❌              | ❌
+| A participant has tried to verify themself with the data of another participant       | Verifications                                    | ❌       | ❌              | ✅
+| An administrator moderated a resource because it has been reported                    | Moderation                                       | ❌       | ✅              | ❌
+| A resource has been reported                                                          | Moderation                                       | ❌       | ❌              | ✅
+| A user confirms the registration (if welcome notification is enabled)                 | User                                             | ❌       | ✅              | ❌
+| A user earned a badge (if badges are enabled)                                         | User                                             | ❌       | ✅              | ❌
+| A user has reached a new badge level (if badges are enabled)                          | User                                             | ❌       | ✅              | ❌
+| A user has been officialized                                                          | User                                             | ❌       | ❌              | ✅
+| A user asked their data export                                                        | User                                             | ❌       | ✅              | ❌
+| A user I follow endorsed a resource                                                   | User                                             | ✅       | ❌              | ❌
+| A public profile has been updated                                                     | User                                             | ✅       | ❌              | ❌
 | A new user group has been created                                                     | User groupsfootnote:[If user groups are enabled] | ❌       | ❌              | ✅
 | A user group has updated its profile                                                  | User groupsfootnote:[If user groups are enabled] | ❌       | ❌              | ✅
 | A user has been invited to join a user group                                          | User groupsfootnote:[If user groups are enabled] | ❌       | ✅              | ❌
@@ -47,81 +47,81 @@ Below is an exhaustive list of actions that trigger notifications to participant
 | A user request to join the user group has been rejected                               | User groupsfootnote:[If user groups are enabled] | ❌       | ✅              | ❌
 | The group admin has been demoted                                                      | User groupsfootnote:[If user groups are enabled] | ❌       | ✅              | ❌
 | The user has been removed from the group                                              | User groupsfootnote:[If user groups are enabled] | ❌       | ✅              | ❌
-| An admin of the assembly has added you as one of its members                          | Assemblies                               | ❌       | ✅              | ❌
-| You have been assigned a role for the assembly                                        | Assemblies                               | ❌       | ✅              | ❌
-| You have been assigned a role for the participatory process                           | Processes                                | ❌       | ✅              | ❌
-| The phases dates have been updated                                                    | Processes                                | ✅       | ❌              | ❌
-| A new phase has been activated                                                        | Processes                                | ✅       | ❌              | ❌
-| You have been assigned a role for the conference                                      | Conferences                              | ❌       | ✅              | ❌
-| The registration to the conference has been confirmed                                 | Conferences                              | ❌       | ✅              | ❌
-| The registration for the conference is open                                           | Conferences                              | ✅       | ❌              | ❌
-| The conference occupied slots are over X%                                             | Conferences                              | ❌       | ❌              | ✅
-| The conference is taking place in 2 days                                              | Conferences                              | ✅       | ❌              | ❌
-| The conference has been updated                                                       | Conferences                              | ✅       | ❌              | ❌
-| The election is now active for the participatory space                                | Elections                                | ✅       | ❌              | ❌
-| You are added as a trustee for the election                                           | Elections                                | ❌       | ✅              | ❌
-| An admin has added you as trustee                                                     | Elections                                | ❌       | ✅              | ❌
-| Your vote was accepted                                                                | Elections                                | ❌       | ✅              | ❌
-| You have been assigned a role of the Polling Station                                  | Elections                                | ❌       | ✅              | ❌
-| Here is your Access Code                                                              | Elections                                | ❌       | ✅              | ❌
-| A user I follow created an initiative                                                 | Initiatives                              | ✅       | ❌              | ❌
-| My initiative has been created                                                        | Initiatives                              | ❌       | ✅              | ❌
-| A user I follow endorsed an initiative                                                | Initiatives                              | ✅       | ❌              | ❌
-| A user sent their initiative to technical validation                                  | Initiatives                              | ❌       | ❌              | ✅
-| The initiative has changed its status                                                 | Initiatives                              | ✅       | ✅              | ❌
-| The signatures end date for the initiative have been extended                         | Initiatives                              | ✅       | ❌              | ❌
-| The request to be part of the promoter committee for the initiative has been accepted | Initiatives                              | ❌       | ✅              | ❌
-| The request to be part of the promoter committee for the initiative has been rejected | Initiatives                              | ❌       | ✅              | ❌
-| A user wants to join your initiative                                                  | Initiatives                              | ❌       | ✅              | ❌
-| The initiative has reached the signatures threshold                                   | Initiatives                              | ❌       | ❌              | ✅
-| Your initiative has achieved the X% of signatures                                     | Initiatives                              | ✅       | ❌              | ❌
-| The initiative has achieved the X% of signatures                                      | Initiatives                              | ❌       | ✅              | ❌
-| The proposal has been included in a result                                            | Accountability                           | ✅       | ❌              | ❌
-| The result progress has been updated                                                  | Accountability                           | ✅       | ❌              | ❌
-| A post has been published                                                             | Blogs                                    | ✅       | ❌              | ❌
-| The budget is now active                                                              | Budgets                                  | ✅       | ❌              | ❌
-| A resource has a comment                                                              | Comments                                 | ✅       | ❌              | ❌
-| A user group has left a comment on a resource                                         | Comments                                 | ✅       | ❌              | ❌
-| A user has left a comment on a resource                                               | Comments                                 | ✅       | ❌              | ❌
-| A user has replied your comment                                                       | Comments                                 | ❌       | ✅              | ❌
-| A group you belong to has been mentioned                                              | Comments                                 | ❌       | ✅              | ❌
-| You have been mentioned                                                               | Comments                                 | ❌       | ✅              | ❌
-| Your comment in has been upvoted                                                      | Comments                                 | ❌       | ✅              | ❌
-| Your comment in has been downvoted                                                    | Comments                                 | ❌       | ✅              | ❌
-| A debate has been created                                                             | Debates                                  | ✅       | ❌              | ❌
-| Debate creation is enabled for participants                                           | Debates                                  | ✅       | ❌              | ❌
-| Debate creation is no longer active                                                   | Debates                                  | ✅       | ❌              | ❌
-| The debate was closed                                                                 | Debates                                  | ✅       | ✅              | ❌
-| A meeting has been created                                                            | Meetings                                 | ✅       | ❌              | ❌
-| A meeting was closed                                                                  | Meetings                                 | ✅       | ✅              | ❌
-| A meeting was updated                                                                 | Meetings                                 | ✅       | ❌              | ❌
-| Your meeting's registration has been confirmed                                        | Meetings                                 | ❌       | ✅              | ❌
-| The allocated slots for the meeting are over X%                                       | Meetings                                 | ❌       | ❌              | ✅
-| The meeting has enabled registrations                                                 | Meetings                                 | ✅       | ❌              | ❌
-| The registration code for the meeting has been validated.                             | Meetings                                 | ❌       | ✅              | ❌
-| The meeting will start in less than 48h                                               | Meetings                                 | ✅       | ❌              | ❌
-| A new proposal has been published                                                     | Proposals                                | ✅       | ❌              | ❌
-| Proposal creation is open                                                             | Proposals                                | ✅       | ❌              | ❌
-| Proposal supports are open                                                            | Proposals                                | ✅       | ❌              | ❌
-| Proposal endorsements are open                                                        | Proposals                                | ✅       | ❌              | ❌
-| Someone has left a note on the proposal                                               | Proposals                                | ❌       | ❌              | ✅
-| A proposal is currently being evaluated                                               | Proposals                                | ✅       | ✅              | ❌
-| A proposal has been rejected                                                          | Proposals                                | ✅       | ✅              | ❌
-| A proposal has been accepted                                                          | Proposals                                | ✅       | ✅              | ❌
-| An admin has updated the scope of your proposal                                       | Proposals                                | ❌       | ✅              | ❌
-| An admin has updated the category of your proposal                                    | Proposals                                | ❌       | ✅              | ❌
-| A proposal has been mentioned                                                         | Proposals                                | ❌       | ✅              | ❌
-| A user requested access as a contributor                                              | Proposal drafts                          | ❌       | ✅              | ❌
-| You have been accepted to access as a contributor                                     | Proposal drafts                          | ❌       | ✅              | ❌
-| You have been rejected to access as a contributor                                     | Proposal drafts                          | ❌       | ✅              | ❌
-| A user has been rejected to access as a contributor                                   | Proposal drafts                          | ❌       | ✅              | ❌
-| A user has been accepted to access as a contributor                                   | Proposal drafts                          | ❌       | ✅              | ❌
-| A user withdrawn the collaborative draft                                              | Proposal drafts                          | ❌       | ✅              | ❌
-| An amendment has been rejected                                                        | Amendmentsfootnote:[If amendments are enabled] | ✅       | ✅              | ❌
-| An amendment has been accepted                                                        | Amendmentsfootnote:[If amendments are enabled] | ✅       | ✅              | ❌
-| An amendment has been created                                                         | Amendmentsfootnote:[If amendments are enabled] | ✅       | ✅              | ❌
-| An amendment has been promoted                                                        | Amendmentsfootnote:[If amendments are enabled] | ✅       | ✅              | ❌
-| A sortition has been created                                                          | Sortitions                               | ✅       | ❌              | ❌
-| A survey has been opened                                                              | Surveys                                  | ✅       | ❌              | ❌
-| A survey has been closed                                                              | Surveys                                  | ✅       | ❌              | ❌
+| An admin of the assembly has added you as one of its members                          | Assemblies                                       | ❌       | ✅              | ❌
+| You have been assigned a role for the assembly                                        | Assemblies                                       | ❌       | ✅              | ❌
+| You have been assigned a role for the participatory process                           | Processes                                        | ❌       | ✅              | ❌
+| The phases dates have been updated                                                    | Processes                                        | ✅       | ❌              | ❌
+| A new phase has been activated                                                        | Processes                                        | ✅       | ❌              | ❌
+| You have been assigned a role for the conference                                      | Conferences                                      | ❌       | ✅              | ❌
+| The registration to the conference has been confirmed                                 | Conferences                                      | ❌       | ✅              | ❌
+| The registration for the conference is open                                           | Conferences                                      | ✅       | ❌              | ❌
+| The conference occupied slots are over X%                                             | Conferences                                      | ❌       | ❌              | ✅
+| The conference is taking place in 2 days                                              | Conferences                                      | ✅       | ❌              | ❌
+| The conference has been updated                                                       | Conferences                                      | ✅       | ❌              | ❌
+| The election is now active for the participatory space                                | Elections                                        | ✅       | ❌              | ❌
+| You are added as a trustee for the election                                           | Elections                                        | ❌       | ✅              | ❌
+| An admin has added you as trustee                                                     | Elections                                        | ❌       | ✅              | ❌
+| Your vote was accepted                                                                | Elections                                        | ❌       | ✅              | ❌
+| You have been assigned a role of the Polling Station                                  | Elections                                        | ❌       | ✅              | ❌
+| Here is your Access Code                                                              | Elections                                        | ❌       | ✅              | ❌
+| A user I follow created an initiative                                                 | Initiatives                                      | ✅       | ❌              | ❌
+| My initiative has been created                                                        | Initiatives                                      | ❌       | ✅              | ❌
+| A user I follow endorsed an initiative                                                | Initiatives                                      | ✅       | ❌              | ❌
+| A user sent their initiative to technical validation                                  | Initiatives                                      | ❌       | ❌              | ✅
+| The initiative has changed its status                                                 | Initiatives                                      | ✅       | ✅              | ❌
+| The signatures end date for the initiative have been extended                         | Initiatives                                      | ✅       | ❌              | ❌
+| The request to be part of the promoter committee for the initiative has been accepted | Initiatives                                      | ❌       | ✅              | ❌
+| The request to be part of the promoter committee for the initiative has been rejected | Initiatives                                      | ❌       | ✅              | ❌
+| A user wants to join your initiative                                                  | Initiatives                                      | ❌       | ✅              | ❌
+| The initiative has reached the signatures threshold                                   | Initiatives                                      | ❌       | ❌              | ✅
+| Your initiative has achieved the X% of signatures                                     | Initiatives                                      | ✅       | ❌              | ❌
+| The initiative has achieved the X% of signatures                                      | Initiatives                                      | ❌       | ✅              | ❌
+| The proposal has been included in a result                                            | Accountability                                   | ✅       | ❌              | ❌
+| The result progress has been updated                                                  | Accountability                                   | ✅       | ❌              | ❌
+| A post has been published                                                             | Blogs                                            | ✅       | ❌              | ❌
+| The budget is now active                                                              | Budgets                                          | ✅       | ❌              | ❌
+| A resource has a comment                                                              | Comments                                         | ✅       | ❌              | ❌
+| A user group has left a comment on a resource                                         | Comments                                         | ✅       | ❌              | ❌
+| A user has left a comment on a resource                                               | Comments                                         | ✅       | ❌              | ❌
+| A user has replied your comment                                                       | Comments                                         | ❌       | ✅              | ❌
+| A group you belong to has been mentioned                                              | Comments                                         | ❌       | ✅              | ❌
+| You have been mentioned                                                               | Comments                                         | ❌       | ✅              | ❌
+| Your comment in has been upvoted                                                      | Comments                                         | ❌       | ✅              | ❌
+| Your comment in has been downvoted                                                    | Comments                                         | ❌       | ✅              | ❌
+| A debate has been created                                                             | Debates                                          | ✅       | ❌              | ❌
+| Debate creation is enabled for participants                                           | Debates                                          | ✅       | ❌              | ❌
+| Debate creation is no longer active                                                   | Debates                                          | ✅       | ❌              | ❌
+| The debate was closed                                                                 | Debates                                          | ✅       | ✅              | ❌
+| A meeting has been created                                                            | Meetings                                         | ✅       | ❌              | ❌
+| A meeting was closed                                                                  | Meetings                                         | ✅       | ✅              | ❌
+| A meeting was updated                                                                 | Meetings                                         | ✅       | ❌              | ❌
+| Your meeting's registration has been confirmed                                        | Meetings                                         | ❌       | ✅              | ❌
+| The allocated slots for the meeting are over X%                                       | Meetings                                         | ❌       | ❌              | ✅
+| The meeting has enabled registrations                                                 | Meetings                                         | ✅       | ❌              | ❌
+| The registration code for the meeting has been validated.                             | Meetings                                         | ❌       | ✅              | ❌
+| The meeting will start in less than 48h                                               | Meetings                                         | ✅       | ❌              | ❌
+| A new proposal has been published                                                     | Proposals                                        | ✅       | ❌              | ❌
+| Proposal creation is open                                                             | Proposals                                        | ✅       | ❌              | ❌
+| Proposal supports are open                                                            | Proposals                                        | ✅       | ❌              | ❌
+| Proposal endorsements are open                                                        | Proposals                                        | ✅       | ❌              | ❌
+| Someone has left a note on the proposal                                               | Proposals                                        | ❌       | ❌              | ✅
+| A proposal is currently being evaluated                                               | Proposals                                        | ✅       | ✅              | ❌
+| A proposal has been rejected                                                          | Proposals                                        | ✅       | ✅              | ❌
+| A proposal has been accepted                                                          | Proposals                                        | ✅       | ✅              | ❌
+| An admin has updated the scope of your proposal                                       | Proposals                                        | ❌       | ✅              | ❌
+| An admin has updated the category of your proposal                                    | Proposals                                        | ❌       | ✅              | ❌
+| A proposal has been mentioned                                                         | Proposals                                        | ❌       | ✅              | ❌
+| A user requested access as a contributor                                              | Proposal drafts                                  | ❌       | ✅              | ❌
+| You have been accepted to access as a contributor                                     | Proposal drafts                                  | ❌       | ✅              | ❌
+| You have been rejected to access as a contributor                                     | Proposal drafts                                  | ❌       | ✅              | ❌
+| A user has been rejected to access as a contributor                                   | Proposal drafts                                  | ❌       | ✅              | ❌
+| A user has been accepted to access as a contributor                                   | Proposal drafts                                  | ❌       | ✅              | ❌
+| A user withdrawn the collaborative draft                                              | Proposal drafts                                  | ❌       | ✅              | ❌
+| An amendment has been rejected                                                        | Amendmentsfootnote:[If amendments are enabled]   | ✅       | ✅              | ❌
+| An amendment has been accepted                                                        | Amendmentsfootnote:[If amendments are enabled]   | ✅       | ✅              | ❌
+| An amendment has been created                                                         | Amendmentsfootnote:[If amendments are enabled]   | ✅       | ✅              | ❌
+| An amendment has been promoted                                                        | Amendmentsfootnote:[If amendments are enabled]   | ✅       | ✅              | ❌
+| A sortition has been created                                                          | Sortitions                                       | ✅       | ❌              | ❌
+| A survey has been opened                                                              | Surveys                                          | ✅       | ❌              | ❌
+| A survey has been closed                                                              | Surveys                                          | ✅       | ❌              | ❌
 |============================================================================================================================================================================

--- a/docs/en/modules/admin/pages/features/notifications.adoc
+++ b/docs/en/modules/admin/pages/features/notifications.adoc
@@ -19,109 +19,114 @@ image:features/notifications/no_notifications_yet.png[Example of notifications p
 
 == Notifications list
 
-Below is an exhaustive list of actions that trigger notifications to participants. Participants are divided into three categories: followers, affected users, and administrators.
+Below is an exhaustive list of actions that trigger notifications to participants. Participants are divided into three categories: affected users, followers, and administrators.
+
+[NOTE]
+====
+Affected user's depend in the notification context. For instance it could be the author of a moderated content, a user that earns a badge, a user that has been mentioned, etc.
+====
 
 [cols="7,2,1,1,1"]
 |============================================================================================================================================================================
-| Action                                                                                | Feature                                                    | Follower | Affected user   | Administrator
+| Action                                                                                | Feature                                                    | Affected user  | Follower  | Administrator
 
-| A new attachment has been created                                                     | Admin                                                      | ✅       | ❌              | ❌
-| An admin requested an export                                                          | Admin                                                      | ❌       | ❌              | ✅
-| A component has been published in a participatory space                               | Admin                                                      | ✅       | ❌              | ❌
-| A participant has tried to verify themself with the data of another participant       | Verifications                                              | ❌       | ❌              | ✅
-| An administrator moderated a resource because it has been reported                    | Moderation                                                 | ❌       | ✅              | ❌
-| A resource has been reported                                                          | Moderation                                                 | ❌       | ❌              | ✅
-| A user confirms the registration (if welcome notification is enabled)                 | User                                                       | ❌       | ✅              | ❌
-| A user earned a badge (if badges are enabled)                                         | User                                                       | ❌       | ✅              | ❌
-| A user has reached a new badge level (if badges are enabled)                          | User                                                       | ❌       | ✅              | ❌
-| A user has been officialized                                                          | User                                                       | ❌       | ❌              | ✅
-| A user asked their data export                                                        | User                                                       | ❌       | ✅              | ❌
-| A user I follow endorsed a resource                                                   | User                                                       | ✅       | ❌              | ❌
-| A public profile has been updated                                                     | User                                                       | ✅       | ❌              | ❌
-| A new user group has been created                                                     | User groupsfootnote:user-group[If user groups are enabled] | ❌       | ❌              | ✅
-| A user group has updated its profile                                                  | User groupsfootnote:user-group[]                           | ❌       | ❌              | ✅
-| A user has been invited to join a user group                                          | User groupsfootnote:user-group[]                           | ❌       | ✅              | ❌
-| A user has been promoted as group admin                                               | User groupsfootnote:user-group[]                           | ❌       | ✅              | ❌
-| A user requested to join the user group                                               | User groupsfootnote:user-group[]                           | ❌       | ✅              | ❌
-| A user request has been accepted to join the user group                               | User groupsfootnote:user-group[]                           | ❌       | ✅              | ❌
-| A user request to join the user group has been rejected                               | User groupsfootnote:user-group[]                           | ❌       | ✅              | ❌
-| The group admin has been demoted                                                      | User groupsfootnote:user-group[]                           | ❌       | ✅              | ❌
-| The user has been removed from the group                                              | User groupsfootnote:user-group[]                           | ❌       | ✅              | ❌
-| An admin of the assembly has added you as one of its members                          | Assemblies                                                 | ❌       | ✅              | ❌
-| You have been assigned a role for the assembly                                        | Assemblies                                                 | ❌       | ✅              | ❌
-| You have been assigned a role for the participatory process                           | Processes                                                  | ❌       | ✅              | ❌
-| The phases dates have been updated                                                    | Processes                                                  | ✅       | ❌              | ❌
-| A new phase has been activated                                                        | Processes                                                  | ✅       | ❌              | ❌
-| You have been assigned a role for the conference                                      | Conferences                                                | ❌       | ✅              | ❌
-| The registration to the conference has been confirmed                                 | Conferences                                                | ❌       | ✅              | ❌
-| The registration for the conference is open                                           | Conferences                                                | ✅       | ❌              | ❌
-| The conference occupied slots are over X%                                             | Conferences                                                | ❌       | ❌              | ✅
-| The conference is taking place in 2 days                                              | Conferences                                                | ✅       | ❌              | ❌
-| The conference has been updated                                                       | Conferences                                                | ✅       | ❌              | ❌
-| The election is now active for the participatory space                                | Elections                                                  | ✅       | ❌              | ❌
-| You are added as a trustee for the election                                           | Elections                                                  | ❌       | ✅              | ❌
-| An admin has added you as trustee                                                     | Elections                                                  | ❌       | ✅              | ❌
-| Your vote was accepted                                                                | Elections                                                  | ❌       | ✅              | ❌
-| You have been assigned a role of the Polling Station                                  | Elections                                                  | ❌       | ✅              | ❌
-| Here is your Access Code                                                              | Elections                                                  | ❌       | ✅              | ❌
-| A user I follow created an initiative                                                 | Initiatives                                                | ✅       | ❌              | ❌
-| My initiative has been created                                                        | Initiatives                                                | ❌       | ✅              | ❌
-| A user I follow endorsed an initiative                                                | Initiatives                                                | ✅       | ❌              | ❌
-| A user sent their initiative to technical validation                                  | Initiatives                                                | ❌       | ❌              | ✅
-| The initiative has changed its status                                                 | Initiatives                                                | ✅       | ✅              | ❌
-| The signatures end date for the initiative have been extended                         | Initiatives                                                | ✅       | ❌              | ❌
-| The request to be part of the promoter committee for the initiative has been accepted | Initiatives                                                | ❌       | ✅              | ❌
-| The request to be part of the promoter committee for the initiative has been rejected | Initiatives                                                | ❌       | ✅              | ❌
-| A user wants to join your initiative                                                  | Initiatives                                                | ❌       | ✅              | ❌
-| The initiative has reached the signatures threshold                                   | Initiatives                                                | ❌       | ❌              | ✅
-| Your initiative has achieved the X% of signatures                                     | Initiatives                                                | ✅       | ❌              | ❌
-| The initiative has achieved the X% of signatures                                      | Initiatives                                                | ❌       | ✅              | ❌
-| The proposal has been included in a result                                            | Accountability                                             | ✅       | ❌              | ❌
-| The result progress has been updated                                                  | Accountability                                             | ✅       | ❌              | ❌
-| A post has been published                                                             | Blogs                                                      | ✅       | ❌              | ❌
-| The budget is now active                                                              | Budgets                                                    | ✅       | ❌              | ❌
-| A resource has a comment                                                              | Comments                                                   | ✅       | ❌              | ❌
-| A user group has left a comment on a resource                                         | Comments                                                   | ✅       | ❌              | ❌
-| A user has left a comment on a resource                                               | Comments                                                   | ✅       | ❌              | ❌
-| A user has replied your comment                                                       | Comments                                                   | ❌       | ✅              | ❌
-| A group you belong to has been mentioned                                              | Comments                                                   | ❌       | ✅              | ❌
-| You have been mentioned                                                               | Comments                                                   | ❌       | ✅              | ❌
-| Your comment in has been upvoted                                                      | Comments                                                   | ❌       | ✅              | ❌
-| Your comment in has been downvoted                                                    | Comments                                                   | ❌       | ✅              | ❌
-| A debate has been created                                                             | Debates                                                    | ✅       | ❌              | ❌
-| Debate creation is enabled for participants                                           | Debates                                                    | ✅       | ❌              | ❌
-| Debate creation is no longer active                                                   | Debates                                                    | ✅       | ❌              | ❌
-| The debate was closed                                                                 | Debates                                                    | ✅       | ✅              | ❌
-| A meeting has been created                                                            | Meetings                                                   | ✅       | ❌              | ❌
-| A meeting was closed                                                                  | Meetings                                                   | ✅       | ✅              | ❌
-| A meeting was updated                                                                 | Meetings                                                   | ✅       | ❌              | ❌
-| Your meeting's registration has been confirmed                                        | Meetings                                                   | ❌       | ✅              | ❌
-| The allocated slots for the meeting are over X%                                       | Meetings                                                   | ❌       | ❌              | ✅
-| The meeting has enabled registrations                                                 | Meetings                                                   | ✅       | ❌              | ❌
-| The registration code for the meeting has been validated.                             | Meetings                                                   | ❌       | ✅              | ❌
-| The meeting will start in less than 48h                                               | Meetings                                                   | ✅       | ❌              | ❌
-| A new proposal has been published                                                     | Proposals                                                  | ✅       | ❌              | ❌
-| Proposal creation is open                                                             | Proposals                                                  | ✅       | ❌              | ❌
-| Proposal supports are open                                                            | Proposals                                                  | ✅       | ❌              | ❌
-| Proposal endorsements are open                                                        | Proposals                                                  | ✅       | ❌              | ❌
-| Someone has left a note on the proposal                                               | Proposals                                                  | ❌       | ❌              | ✅
-| A proposal is currently being evaluated                                               | Proposals                                                  | ✅       | ✅              | ❌
-| A proposal has been rejected                                                          | Proposals                                                  | ✅       | ✅              | ❌
-| A proposal has been accepted                                                          | Proposals                                                  | ✅       | ✅              | ❌
-| An admin has updated the scope of your proposal                                       | Proposals                                                  | ❌       | ✅              | ❌
-| An admin has updated the category of your proposal                                    | Proposals                                                  | ❌       | ✅              | ❌
-| A proposal has been mentioned                                                         | Proposals                                                  | ❌       | ✅              | ❌
-| A user requested access as a contributor                                              | Proposal drafts                                            | ❌       | ✅              | ❌
-| You have been accepted to access as a contributor                                     | Proposal drafts                                            | ❌       | ✅              | ❌
-| You have been rejected to access as a contributor                                     | Proposal drafts                                            | ❌       | ✅              | ❌
-| A user has been rejected to access as a contributor                                   | Proposal drafts                                            | ❌       | ✅              | ❌
-| A user has been accepted to access as a contributor                                   | Proposal drafts                                            | ❌       | ✅              | ❌
-| A user withdrawn the collaborative draft                                              | Proposal drafts                                            | ❌       | ✅              | ❌
-| An amendment has been rejected                                                        | Amendmentsfootnote:amendments[If amendments are enabled]   | ✅       | ✅              | ❌
-| An amendment has been accepted                                                        | Amendmentsfootnote:amendments[]                            | ✅       | ✅              | ❌
-| An amendment has been created                                                         | Amendmentsfootnote:amendments[]                            | ✅       | ✅              | ❌
-| An amendment has been promoted                                                        | Amendmentsfootnote:amendments[]                            | ✅       | ✅              | ❌
-| A sortition has been created                                                          | Sortitions                                                 | ✅       | ❌              | ❌
-| A survey has been opened                                                              | Surveys                                                    | ✅       | ❌              | ❌
-| A survey has been closed                                                              | Surveys                                                    | ✅       | ❌              | ❌
+| A new attachment has been created                                                     | Admin                                                      | ❌             | ✅        | ❌
+| An admin requested an export                                                          | Admin                                                      | ❌             | ❌        | ✅
+| A component has been published in a participatory space                               | Admin                                                      | ❌             | ✅        | ❌
+| A participant has tried to verify themself with the data of another participant       | Verifications                                              | ❌             | ❌        | ✅
+| An administrator moderated a resource because it has been reported                    | Moderation                                                 | ✅             | ❌        | ❌
+| A resource has been reported                                                          | Moderation                                                 | ❌             | ❌        | ✅
+| A user confirms the registration (if welcome notification is enabled)                 | User                                                       | ✅             | ❌        | ❌
+| A user earned a badge (if badges are enabled)                                         | User                                                       | ✅             | ❌        | ❌
+| A user has reached a new badge level (if badges are enabled)                          | User                                                       | ✅             | ❌        | ❌
+| A user has been officialized                                                          | User                                                       | ❌             | ❌        | ✅
+| A user asked their data export                                                        | User                                                       | ✅             | ❌        | ❌
+| A user I follow endorsed a resource                                                   | User                                                       | ❌             | ✅        | ❌
+| A public profile has been updated                                                     | User                                                       | ❌             | ✅        | ❌
+| A new user group has been created                                                     | User groupsfootnote:user-group[If user groups are enabled] | ❌             | ❌        | ✅
+| A user group has updated its profile                                                  | User groupsfootnote:user-group[]                           | ❌             | ❌        | ✅
+| A user has been invited to join a user group                                          | User groupsfootnote:user-group[]                           | ✅             | ❌        | ❌
+| A user has been promoted as group admin                                               | User groupsfootnote:user-group[]                           | ✅             | ❌        | ❌
+| A user requested to join the user group                                               | User groupsfootnote:user-group[]                           | ✅             | ❌        | ❌
+| A user request has been accepted to join the user group                               | User groupsfootnote:user-group[]                           | ✅             | ❌        | ❌
+| A user request to join the user group has been rejected                               | User groupsfootnote:user-group[]                           | ✅             | ❌        | ❌
+| The group admin has been demoted                                                      | User groupsfootnote:user-group[]                           | ✅             | ❌        | ❌
+| The user has been removed from the group                                              | User groupsfootnote:user-group[]                           | ✅             | ❌        | ❌
+| An admin of the assembly has added you as one of its members                          | Assemblies                                                 | ✅             | ❌        | ❌
+| You have been assigned a role for the assembly                                        | Assemblies                                                 | ✅             | ❌        | ❌
+| You have been assigned a role for the participatory process                           | Processes                                                  | ✅             | ❌        | ❌
+| The phases dates have been updated                                                    | Processes                                                  | ❌             | ✅        | ❌
+| A new phase has been activated                                                        | Processes                                                  | ❌             | ✅        | ❌
+| You have been assigned a role for the conference                                      | Conferences                                                | ✅             | ❌        | ❌
+| The registration to the conference has been confirmed                                 | Conferences                                                | ✅             | ❌        | ❌
+| The registration for the conference is open                                           | Conferences                                                | ❌             | ✅        | ❌
+| The conference occupied slots are over X%                                             | Conferences                                                | ❌             | ❌        | ✅
+| The conference is taking place in 2 days                                              | Conferences                                                | ❌             | ✅        | ❌
+| The conference has been updated                                                       | Conferences                                                | ❌             | ✅        | ❌
+| The election is now active for the participatory space                                | Elections                                                  | ❌             | ✅        | ❌
+| You are added as a trustee for the election                                           | Elections                                                  | ✅             | ❌        | ❌
+| An admin has added you as trustee                                                     | Elections                                                  | ✅             | ❌        | ❌
+| Your vote was accepted                                                                | Elections                                                  | ✅             | ❌        | ❌
+| You have been assigned a role of the Polling Station                                  | Elections                                                  | ✅             | ❌        | ❌
+| Here is your Access Code                                                              | Elections                                                  | ✅             | ❌        | ❌
+| A user I follow created an initiative                                                 | Initiatives                                                | ❌             | ✅        | ❌
+| My initiative has been created                                                        | Initiatives                                                | ✅             | ❌        | ❌
+| A user I follow endorsed an initiative                                                | Initiatives                                                | ❌             | ✅        | ❌
+| A user sent their initiative to technical validation                                  | Initiatives                                                | ❌             | ❌        | ✅
+| The initiative has changed its status                                                 | Initiatives                                                | ✅             | ✅        | ❌
+| The signatures end date for the initiative have been extended                         | Initiatives                                                | ❌             | ✅        | ❌
+| The request to be part of the promoter committee for the initiative has been accepted | Initiatives                                                | ✅             | ❌        | ❌
+| The request to be part of the promoter committee for the initiative has been rejected | Initiatives                                                | ✅             | ❌        | ❌
+| A user wants to join your initiative                                                  | Initiatives                                                | ✅             | ❌        | ❌
+| The initiative has reached the signatures threshold                                   | Initiatives                                                | ❌             | ❌        | ✅
+| Your initiative has achieved the X% of signatures                                     | Initiatives                                                | ❌             | ✅        | ❌
+| The initiative has achieved the X% of signatures                                      | Initiatives                                                | ✅             | ❌        | ❌
+| The proposal has been included in a result                                            | Accountability                                             | ❌             | ✅        | ❌
+| The result progress has been updated                                                  | Accountability                                             | ❌             | ✅        | ❌
+| A post has been published                                                             | Blogs                                                      | ❌             | ✅        | ❌
+| The budget is now active                                                              | Budgets                                                    | ❌             | ✅        | ❌
+| A resource has a comment                                                              | Comments                                                   | ❌             | ✅        | ❌
+| A user group has left a comment on a resource                                         | Comments                                                   | ❌             | ✅        | ❌
+| A user has left a comment on a resource                                               | Comments                                                   | ❌             | ✅        | ❌
+| A user has replied your comment                                                       | Comments                                                   | ✅             | ❌        | ❌
+| A group you belong to has been mentioned                                              | Comments                                                   | ✅             | ❌        | ❌
+| You have been mentioned                                                               | Comments                                                   | ✅             | ❌        | ❌
+| Your comment in has been upvoted                                                      | Comments                                                   | ✅             | ❌        | ❌
+| Your comment in has been downvoted                                                    | Comments                                                   | ✅             | ❌        | ❌
+| A debate has been created                                                             | Debates                                                    | ❌             | ✅        | ❌
+| Debate creation is enabled for participants                                           | Debates                                                    | ❌             | ✅        | ❌
+| Debate creation is no longer active                                                   | Debates                                                    | ❌             | ✅        | ❌
+| The debate was closed                                                                 | Debates                                                    | ✅             | ✅        | ❌
+| A meeting has been created                                                            | Meetings                                                   | ❌             | ✅        | ❌
+| A meeting was closed                                                                  | Meetings                                                   | ✅             | ✅        | ❌
+| A meeting was updated                                                                 | Meetings                                                   | ❌             | ✅        | ❌
+| Your meeting's registration has been confirmed                                        | Meetings                                                   | ✅             | ❌        | ❌
+| The allocated slots for the meeting are over X%                                       | Meetings                                                   | ❌             | ❌        | ✅
+| The meeting has enabled registrations                                                 | Meetings                                                   | ❌             | ✅        | ❌
+| The registration code for the meeting has been validated.                             | Meetings                                                   | ✅             | ❌        | ❌
+| The meeting will start in less than 48h                                               | Meetings                                                   | ❌             | ✅        | ❌
+| A new proposal has been published                                                     | Proposals                                                  | ❌             | ✅        | ❌
+| Proposal creation is open                                                             | Proposals                                                  | ❌             | ✅        | ❌
+| Proposal supports are open                                                            | Proposals                                                  | ❌             | ✅        | ❌
+| Proposal endorsements are open                                                        | Proposals                                                  | ❌             | ✅        | ❌
+| Someone has left a note on the proposal                                               | Proposals                                                  | ❌             | ❌        | ✅
+| A proposal is currently being evaluated                                               | Proposals                                                  | ✅             | ✅        | ❌
+| A proposal has been rejected                                                          | Proposals                                                  | ✅             | ✅        | ❌
+| A proposal has been accepted                                                          | Proposals                                                  | ✅             | ✅        | ❌
+| An admin has updated the scope of your proposal                                       | Proposals                                                  | ✅             | ❌        | ❌
+| An admin has updated the category of your proposal                                    | Proposals                                                  | ✅             | ❌        | ❌
+| A proposal has been mentioned                                                         | Proposals                                                  | ✅             | ❌        | ❌
+| A user requested access as a contributor                                              | Proposal drafts                                            | ✅             | ❌        | ❌
+| You have been accepted to access as a contributor                                     | Proposal drafts                                            | ✅             | ❌        | ❌
+| You have been rejected to access as a contributor                                     | Proposal drafts                                            | ✅             | ❌        | ❌
+| A user has been rejected to access as a contributor                                   | Proposal drafts                                            | ✅             | ❌        | ❌
+| A user has been accepted to access as a contributor                                   | Proposal drafts                                            | ✅             | ❌        | ❌
+| A user withdrawn the collaborative draft                                              | Proposal drafts                                            | ✅             | ❌        | ❌
+| An amendment has been rejected                                                        | Amendmentsfootnote:amendments[If amendments are enabled]   | ✅             | ✅        | ❌
+| An amendment has been accepted                                                        | Amendmentsfootnote:amendments[]                            | ✅             | ✅        | ❌
+| An amendment has been created                                                         | Amendmentsfootnote:amendments[]                            | ✅             | ✅        | ❌
+| An amendment has been promoted                                                        | Amendmentsfootnote:amendments[]                            | ✅             | ✅        | ❌
+| A sortition has been created                                                          | Sortitions                                                 | ❌             | ✅        | ❌
+| A survey has been opened                                                              | Surveys                                                    | ❌             | ✅        | ❌
+| A survey has been closed                                                              | Surveys                                                    | ❌             | ✅        | ❌
 |============================================================================================================================================================================

--- a/docs/en/modules/admin/pages/features/notifications.adoc
+++ b/docs/en/modules/admin/pages/features/notifications.adoc
@@ -26,102 +26,102 @@ Below is an exhaustive list of actions that trigger notifications to participant
 | Action                                                                                | Component                                | Follower | Affected user   | Administrator
 
 | A new attachment has been created                                                     | Admin                                    | ✅       | ❌              | ❌
-| An admin requested an export                                                          |                                          | ❌       | ❌              | ✅
-| A component has been published in a participatory space                               |                                          | ✅       | ❌              | ❌
+| An admin requested an export                                                          | Admin                                    | ❌       | ❌              | ✅
+| A component has been published in a participatory space                               | Admin                                    | ✅       | ❌              | ❌
 | A participant has tried to verify themself with the data of another participant       | Verifications                            | ❌       | ❌              | ✅
 | An administrator moderated a resource because it has been reported                    | Moderation                               | ❌       | ✅              | ❌
-| A resource has been reported                                                          |                                          | ❌       | ❌              | ✅
+| A resource has been reported                                                          | Moderation                               | ❌       | ❌              | ✅
 | A user confirms the registration (if welcome notification is enabled)                 | User                                     | ❌       | ✅              | ❌
-| A user earned a badge (if badges are enabled)                                         |                                          | ❌       | ✅              | ❌
-| A user has reached a new badge level (if badges are enabled)                          |                                          | ❌       | ✅              | ❌
-| A user has been officialized                                                          |                                          | ❌       | ❌              | ✅
-| A user asked their data export                                                        |                                          | ❌       | ✅              | ❌
-| A user I follow endorsed a resource                                                   |                                          | ✅       | ❌              | ❌
-| A public profile has been updated                                                     |                                          | ✅       | ❌              | ❌
+| A user earned a badge (if badges are enabled)                                         | User                                     | ❌       | ✅              | ❌
+| A user has reached a new badge level (if badges are enabled)                          | User                                     | ❌       | ✅              | ❌
+| A user has been officialized                                                          | User                                     | ❌       | ❌              | ✅
+| A user asked their data export                                                        | User                                     | ❌       | ✅              | ❌
+| A user I follow endorsed a resource                                                   | User                                     | ✅       | ❌              | ❌
+| A public profile has been updated                                                     | User                                     | ✅       | ❌              | ❌
 | A new user group has been created                                                     | User groups (if user groups are enabled) | ❌       | ❌              | ✅
-| A user group has updated its profile                                                  |                                          | ❌       | ❌              | ✅
-| A user has been invited to join a user group                                          |                                          | ❌       | ✅              | ❌
-| A user has been promoted as group admin                                               |                                          | ❌       | ✅              | ❌
-| A user requested to join the user group                                               |                                          | ❌       | ✅              | ❌
-| A user request has been accepted to join the user group                               |                                          | ❌       | ✅              | ❌
-| A user request to join the user group has been rejected                               |                                          | ❌       | ✅              | ❌
-| The group admin has been demoted                                                      |                                          | ❌       | ✅              | ❌
-| The user has been removed from the group                                              |                                          | ❌       | ✅              | ❌
+| A user group has updated its profile                                                  | User groups (if user groups are enabled) | ❌       | ❌              | ✅
+| A user has been invited to join a user group                                          | User groups (if user groups are enabled) | ❌       | ✅              | ❌
+| A user has been promoted as group admin                                               | User groups (if user groups are enabled) | ❌       | ✅              | ❌
+| A user requested to join the user group                                               | User groups (if user groups are enabled) | ❌       | ✅              | ❌
+| A user request has been accepted to join the user group                               | User groups (if user groups are enabled) | ❌       | ✅              | ❌
+| A user request to join the user group has been rejected                               | User groups (if user groups are enabled) | ❌       | ✅              | ❌
+| The group admin has been demoted                                                      | User groups (if user groups are enabled) | ❌       | ✅              | ❌
+| The user has been removed from the group                                              | User groups (if user groups are enabled) | ❌       | ✅              | ❌
 | An admin of the assembly has added you as one of its members                          | Assemblies                               | ❌       | ✅              | ❌
-| You have been assigned a role for the assembly                                        |                                          | ❌       | ✅              | ❌
+| You have been assigned a role for the assembly                                        | Assemblies                               | ❌       | ✅              | ❌
 | You have been assigned a role for the participatory process                           | Processes                                | ❌       | ✅              | ❌
-| The phases dates have been updated                                                    |                                          | ✅       | ❌              | ❌
-| A new phase has been activated                                                        |                                          | ✅       | ❌              | ❌
+| The phases dates have been updated                                                    | Processes                                | ✅       | ❌              | ❌
+| A new phase has been activated                                                        | Processes                                | ✅       | ❌              | ❌
 | You have been assigned a role for the conference                                      | Conferences                              | ❌       | ✅              | ❌
-| The registration to the conference has been confirmed                                 |                                          | ❌       | ✅              | ❌
-| The registration for the conference is open                                           |                                          | ✅       | ❌              | ❌
-| The conference occupied slots are over X%                                             |                                          | ❌       | ❌              | ✅
-| The conference is taking place in 2 days                                              |                                          | ✅       | ❌              | ❌
-| The conference has been updated                                                       |                                          | ✅       | ❌              | ❌
+| The registration to the conference has been confirmed                                 | Conferences                              | ❌       | ✅              | ❌
+| The registration for the conference is open                                           | Conferences                              | ✅       | ❌              | ❌
+| The conference occupied slots are over X%                                             | Conferences                              | ❌       | ❌              | ✅
+| The conference is taking place in 2 days                                              | Conferences                              | ✅       | ❌              | ❌
+| The conference has been updated                                                       | Conferences                              | ✅       | ❌              | ❌
 | The election is now active for the participatory space                                | Elections                                | ✅       | ❌              | ❌
-| You are added as a trustee for the election                                           |                                          | ❌       | ✅              | ❌
-| An admin has added you as trustee                                                     |                                          | ❌       | ✅              | ❌
-| Your vote was accepted                                                                |                                          | ❌       | ✅              | ❌
-| You have been assigned a role of the Polling Station                                  |                                          | ❌       | ✅              | ❌
-| Here is your Access Code                                                              |                                          | ❌       | ✅              | ❌
+| You are added as a trustee for the election                                           | Elections                                | ❌       | ✅              | ❌
+| An admin has added you as trustee                                                     | Elections                                | ❌       | ✅              | ❌
+| Your vote was accepted                                                                | Elections                                | ❌       | ✅              | ❌
+| You have been assigned a role of the Polling Station                                  | Elections                                | ❌       | ✅              | ❌
+| Here is your Access Code                                                              | Elections                                | ❌       | ✅              | ❌
 | A user I follow created an initiative                                                 | Initiatives                              | ✅       | ❌              | ❌
-| My initiative has been created                                                        |                                          | ❌       | ✅              | ❌
-| A user I follow endorsed an initiative                                                |                                          | ✅       | ❌              | ❌
-| A user sent their initiative to technical validation                                  |                                          | ❌       | ❌              | ✅
-| The initiative has changed its status                                                 |                                          | ✅       | ✅              | ❌
-| The signatures end date for the initiative have been extended                         |                                          | ✅       | ❌              | ❌
-| The request to be part of the promoter committee for the initiative has been accepted |                                          | ❌       | ✅              | ❌
-| The request to be part of the promoter committee for the initiative has been rejected |                                          | ❌       | ✅              | ❌
-| A user wants to join your initiative                                                  |                                          | ❌       | ✅              | ❌
-| The initiative has reached the signatures threshold                                   |                                          | ❌       | ❌              | ✅
-| Your initiative has achieved the X% of signatures                                     |                                          | ✅       | ❌              | ❌
-| The initiative has achieved the X% of signatures                                      |                                          | ❌       | ✅              | ❌
+| My initiative has been created                                                        | Initiatives                              | ❌       | ✅              | ❌
+| A user I follow endorsed an initiative                                                | Initiatives                              | ✅       | ❌              | ❌
+| A user sent their initiative to technical validation                                  | Initiatives                              | ❌       | ❌              | ✅
+| The initiative has changed its status                                                 | Initiatives                              | ✅       | ✅              | ❌
+| The signatures end date for the initiative have been extended                         | Initiatives                              | ✅       | ❌              | ❌
+| The request to be part of the promoter committee for the initiative has been accepted | Initiatives                              | ❌       | ✅              | ❌
+| The request to be part of the promoter committee for the initiative has been rejected | Initiatives                              | ❌       | ✅              | ❌
+| A user wants to join your initiative                                                  | Initiatives                              | ❌       | ✅              | ❌
+| The initiative has reached the signatures threshold                                   | Initiatives                              | ❌       | ❌              | ✅
+| Your initiative has achieved the X% of signatures                                     | Initiatives                              | ✅       | ❌              | ❌
+| The initiative has achieved the X% of signatures                                      | Initiatives                              | ❌       | ✅              | ❌
 | The proposal has been included in a result                                            | Accountability                           | ✅       | ❌              | ❌
-| The result progress has been updated                                                  |                                          | ✅       | ❌              | ❌
+| The result progress has been updated                                                  | Accountability                           | ✅       | ❌              | ❌
 | A post has been published                                                             | Blogs                                    | ✅       | ❌              | ❌
 | The budget is now active                                                              | Budgets                                  | ✅       | ❌              | ❌
 | A resource has a comment                                                              | Comments                                 | ✅       | ❌              | ❌
-| A user group has left a comment on a resource                                         |                                          | ✅       | ❌              | ❌
-| A user has left a comment on a resource                                               |                                          | ✅       | ❌              | ❌
-| A user has replied your comment                                                       |                                          | ❌       | ✅              | ❌
-| A group you belong to has been mentioned                                              |                                          | ❌       | ✅              | ❌
-| You have been mentioned                                                               |                                          | ❌       | ✅              | ❌
-| Your comment in has been upvoted                                                      |                                          | ❌       | ✅              | ❌
-| Your comment in has been downvoted                                                    |                                          | ❌       | ✅              | ❌
+| A user group has left a comment on a resource                                         | Comments                                 | ✅       | ❌              | ❌
+| A user has left a comment on a resource                                               | Comments                                 | ✅       | ❌              | ❌
+| A user has replied your comment                                                       | Comments                                 | ❌       | ✅              | ❌
+| A group you belong to has been mentioned                                              | Comments                                 | ❌       | ✅              | ❌
+| You have been mentioned                                                               | Comments                                 | ❌       | ✅              | ❌
+| Your comment in has been upvoted                                                      | Comments                                 | ❌       | ✅              | ❌
+| Your comment in has been downvoted                                                    | Comments                                 | ❌       | ✅              | ❌
 | A debate has been created                                                             | Debates                                  | ✅       | ❌              | ❌
-| Debate creation is enabled for participants                                           |                                          | ✅       | ❌              | ❌
-| Debate creation is no longer active                                                   |                                          | ✅       | ❌              | ❌
-| The debate was closed                                                                 |                                          | ✅       | ✅              | ❌
+| Debate creation is enabled for participants                                           | Debates                                  | ✅       | ❌              | ❌
+| Debate creation is no longer active                                                   | Debates                                  | ✅       | ❌              | ❌
+| The debate was closed                                                                 | Debates                                  | ✅       | ✅              | ❌
 | A meeting has been created                                                            | Meetings                                 | ✅       | ❌              | ❌
-| A meeting was closed                                                                  |                                          | ✅       | ✅              | ❌
-| A meeting was updated                                                                 |                                          | ✅       | ❌              | ❌
-| Your meeting's registration has been confirmed                                        |                                          | ❌       | ✅              | ❌
-| The allocated slots for the meeting are over X%                                       |                                          | ❌       | ❌              | ✅
-| The meeting has enabled registrations                                                 |                                          | ✅       | ❌              | ❌
-| The registration code for the meeting has been validated.                             |                                          | ❌       | ✅              | ❌
-| The meeting will start in less than 48h                                               |                                          | ✅       | ❌              | ❌
+| A meeting was closed                                                                  | Meetings                                 | ✅       | ✅              | ❌
+| A meeting was updated                                                                 | Meetings                                 | ✅       | ❌              | ❌
+| Your meeting's registration has been confirmed                                        | Meetings                                 | ❌       | ✅              | ❌
+| The allocated slots for the meeting are over X%                                       | Meetings                                 | ❌       | ❌              | ✅
+| The meeting has enabled registrations                                                 | Meetings                                 | ✅       | ❌              | ❌
+| The registration code for the meeting has been validated.                             | Meetings                                 | ❌       | ✅              | ❌
+| The meeting will start in less than 48h                                               | Meetings                                 | ✅       | ❌              | ❌
 | A new proposal has been published                                                     | Proposals                                | ✅       | ❌              | ❌
-| Proposal creation is open                                                             |                                          | ✅       | ❌              | ❌
-| Proposal supports are open                                                            |                                          | ✅       | ❌              | ❌
-| Proposal endorsements are open                                                        |                                          | ✅       | ❌              | ❌
-| Someone has left a note on the proposal                                               |                                          | ❌       | ❌              | ✅
-| A proposal is currently being evaluated                                               |                                          | ✅       | ✅              | ❌
-| A proposal has been rejected                                                          |                                          | ✅       | ✅              | ❌
-| A proposal has been accepted                                                          |                                          | ✅       | ✅              | ❌
-| An admin has updated the scope of your proposal                                       |                                          | ❌       | ✅              | ❌
-| An admin has updated the category of your proposal                                    |                                          | ❌       | ✅              | ❌
-| A proposal has been mentioned                                                         |                                          | ❌       | ✅              | ❌
+| Proposal creation is open                                                             | Proposals                                | ✅       | ❌              | ❌
+| Proposal supports are open                                                            | Proposals                                | ✅       | ❌              | ❌
+| Proposal endorsements are open                                                        | Proposals                                | ✅       | ❌              | ❌
+| Someone has left a note on the proposal                                               | Proposals                                | ❌       | ❌              | ✅
+| A proposal is currently being evaluated                                               | Proposals                                | ✅       | ✅              | ❌
+| A proposal has been rejected                                                          | Proposals                                | ✅       | ✅              | ❌
+| A proposal has been accepted                                                          | Proposals                                | ✅       | ✅              | ❌
+| An admin has updated the scope of your proposal                                       | Proposals                                | ❌       | ✅              | ❌
+| An admin has updated the category of your proposal                                    | Proposals                                | ❌       | ✅              | ❌
+| A proposal has been mentioned                                                         | Proposals                                | ❌       | ✅              | ❌
 | A user requested access as a contributor                                              | Proposal drafts                          | ❌       | ✅              | ❌
-| You have been accepted to access as a contributor                                     |                                          | ❌       | ✅              | ❌
-| You have been rejected to access as a contributor                                     |                                          | ❌       | ✅              | ❌
-| A user has been rejected to access as a contributor                                   |                                          | ❌       | ✅              | ❌
-| A user has been accepted to access as a contributor                                   |                                          | ❌       | ✅              | ❌
-| A user withdrawn the collaborative draft                                              |                                          | ❌       | ✅              | ❌
+| You have been accepted to access as a contributor                                     | Proposal drafts                          | ❌       | ✅              | ❌
+| You have been rejected to access as a contributor                                     | Proposal drafts                          | ❌       | ✅              | ❌
+| A user has been rejected to access as a contributor                                   | Proposal drafts                          | ❌       | ✅              | ❌
+| A user has been accepted to access as a contributor                                   | Proposal drafts                          | ❌       | ✅              | ❌
+| A user withdrawn the collaborative draft                                              | Proposal drafts                          | ❌       | ✅              | ❌
 | An amendment has been rejected                                                        | Amendments (if amendments are enabled)   | ✅       | ✅              | ❌
-| An amendment has been accepted                                                        |                                          | ✅       | ✅              | ❌
-| An amendment has been created                                                         |                                          | ✅       | ✅              | ❌
-| An amendment has been promoted                                                        |                                          | ✅       | ✅              | ❌
+| An amendment has been accepted                                                        | Amendments (if amendments are enabled)   | ✅       | ✅              | ❌
+| An amendment has been created                                                         | Amendments (if amendments are enabled)   | ✅       | ✅              | ❌
+| An amendment has been promoted                                                        | Amendments (if amendments are enabled)   | ✅       | ✅              | ❌
 | A sortition has been created                                                          | Sortitions                               | ✅       | ❌              | ❌
 | A survey has been opened                                                              | Surveys                                  | ✅       | ❌              | ❌
-| A survey has been closed                                                              |                                          | ✅       | ❌              | ❌
+| A survey has been closed                                                              | Surveys                                  | ✅       | ❌              | ❌
 |============================================================================================================================================================================

--- a/docs/en/modules/admin/pages/features/notifications.adoc
+++ b/docs/en/modules/admin/pages/features/notifications.adoc
@@ -19,7 +19,7 @@ image:features/notifications/no_notifications_yet.png[Example of notifications p
 
 == Notifications list
 
-Below is an exhaustive list of actions that trigger notifications to participants. Participants are divided into three categories: assigned users, followers and administrators.
+Below is an exhaustive list of actions that trigger notifications to participants. Participants are divided into three categories: followers, affected users, and administrators.
 
 [cols="7,2,1,1,1"]
 |============================================================================================================================================================================


### PR DESCRIPTION
This PR improves on #146, by tuning a bit some details of the Notifications' list table. 

For reviewing it may makes more sense seeing the changes on a commit by commit basis, but as a summay:

- Clarifies what is an Affected user and makes it first
- Makes a footnote about the User groups and Amendments clarification of "it is enabled")
- Makes the Action the first column, as it is more important than the Component
- Renames Component to Feature as its more generic (we have also Spaces in this column, and they're not Components as we define them in Decidim)
- Repeats the Action in each cell, to improve the accessibility of the table  
- Makes all the column align in plain text

### Screenshots

#### Before

![Screenshot of how it is now](https://github.com/decidim/documentation/assets/717367/9ae16f65-70bf-4903-a9b6-cfd3028dcbad)

#### After

![Screenshot of how it could be if we merge this PR](https://github.com/decidim/documentation/assets/717367/b6299cde-ab81-4ae7-bd43-a34423e2edcf)
