### PR TITLE
Fix typo in groups page

### DIFF
--- a/docs/en/modules/admin/pages/spaces/processes/groups.adoc
+++ b/docs/en/modules/admin/pages/spaces/processes/groups.adoc
@@ -94,7 +94,7 @@ ParticpipatoryProcess Content Block in the xref:admin:homepage.adoc[Homepage] co
 
 == Landing page
 
-One of the main features of a process group is to be able to configure the Lnading page, through Content blocks, just like
+One of the main features of a process group is to be able to configure the Landing page, through Content blocks, just like
 the general homepage of the platform. This means that you can enable or disable different sections of the landing page and also
 configure some fo these sections.
 


### PR DESCRIPTION
This is the same fix done in #157 