### PR TITLE
add the taxonomies menu

### DIFF
--- a/docs/en/modules/ROOT/nav.adoc
+++ b/docs/en/modules/ROOT/nav.adoc
@@ -185,6 +185,7 @@
 *** xref:develop:metrics.adoc[Metrics]
 *** xref:develop:modules.adoc[Modules]
 *** xref:develop:notifications.adoc[Notifications]
+*** xref:develop:taxonomies.adoc[Taxonomies]
 *** xref:develop:open-data.adoc[Open Data]
 *** xref:develop:permissions.adoc[Permissions]
 *** xref:develop:profiling.adoc[Profiling]


### PR DESCRIPTION
Taxonomies documentation was already introduced but has no nav link. This should add it.