### PR TITLE
Remove links to deleted files in decidim/decidim

### DIFF
--- a/docs/en/modules/releases/pages/index.adoc
+++ b/docs/en/modules/releases/pages/index.adoc
@@ -11,8 +11,6 @@ https://github.com/decidim/decidim/releases[GitHub].
 * https://decidim.org/blog/2022-09-30-new-version-0-27-0/[Version 0.27 (2022-09-30)]
 * https://decidim.org/blog/2022-02-22-new-version-0-26-0/[Version 0.26 (2022-02-22)]
 * https://decidim.org/blog/2021-10-07-new-version-0-25-0/[Version 0.25 (2021-10-07)]
-** xref:develop:guide_migrate_webpacker_module.adoc[Migrate to Webpacker a module]
-** xref:develop:guide_migrate_webpacker_app.adoc[Migrate to Webpacker an instance app]
 * https://decidim.org/blog/2021-03-26-new-version-0-24-0/[Version 0.24 (2021-03-26)]
 * https://decidim.org/blog/2020-11-12-new-version-0-23-0/[Version 0.23 (2020-11-12)]
 * https://decidim.org/blog/2020-09-02-new-version-0-22-0/[Version 0.22 (2020-09-02)]


### PR DESCRIPTION
We are removing 2 files from release notes, as they are obsolete. 

The request comes from: https://github.com/decidim/decidim/pull/15016#discussion_r2321620300