### PR TITLE
Update proposal creation as a group

### DIFF
--- a/docs/en/modules/admin/pages/components/proposals/proposals.adoc
+++ b/docs/en/modules/admin/pages/components/proposals/proposals.adoc
@@ -111,7 +111,7 @@ the proposal grid list.
 
 |Create proposal as
 |Optional
-|If the participant belongs to a verified xref:admin:participants/groups.adoc[user group], they can create a proposal in the name of 
+|If the participant is an administrator of a verified xref:admin:participants/groups.adoc[user group], they can create a proposal in the name of 
 this group
 
 |===


### PR DESCRIPTION
The documentation was incomplete, only user group admins can create proposals as a group.