### PR TITLE
Change API documentation location

### DIFF
--- a/docs/en/modules/ROOT/nav.adoc
+++ b/docs/en/modules/ROOT/nav.adoc
@@ -203,7 +203,6 @@
 **** xref:develop:ai_tools/spam_detection_strategy.adoc[Spam detection Strategy]
 **** xref:develop:ai_tools/spam_detection_service.adoc[Spam detection Service]
 **** xref:develop:ai_tools/spam_detection_analyzer.adoc[Spam detection Analyzer]
-*** xref:develop:api.adoc[API]
 *** xref:develop:components.adoc[Components]
 *** xref:develop:content_processors.adoc[Content Processors]
 *** xref:develop:custom_seed_data.adoc[Custom Seed Data]
@@ -235,6 +234,8 @@
 **** xref:develop:newsletter_templates.adoc[Newsletter Templates]
 **** xref:develop:view_hooks.adoc[View Hooks]
 **** xref:develop:view_models_aka_cells.adoc[View Models (Cells)]
+** xref:develop:api/index.adoc[API]
+*** xref:develop:api/proposals/mutations.adoc[Proposals]
 
 * Understand
 ** xref:understand:about.adoc[About]


### PR DESCRIPTION
In this PR, I am changing the location of the API folder from : `Develop / Advanced / API` to `Develop / API `. I am also adding a sub link to proposals mutation page into `Develop / API / Proposals` page.